### PR TITLE
Crypto Package

### DIFF
--- a/pkg/trisa/crypto/aesgcm/aesgcm.go
+++ b/pkg/trisa/crypto/aesgcm/aesgcm.go
@@ -1,0 +1,133 @@
+package aesgcm
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/trisacrypto/testnet/pkg/trisa/crypto"
+)
+
+// AESGCM implements the crypto.Crypto interface using the AES-GCM algorithm for
+// symmetric-key encryption. This algorithm is widely adopted for it's performance and
+// throughput rates for state-of-the-art high-speed communication on inexpensive
+// hardware (Wikipedia). This implementation generates a 32 byte random encryption key
+// when initialized, if one not specified by default. Users should create a new AESGCM
+// to encrypt and sign different messages with different keys.
+type AESGCM struct {
+	key    []byte // the symmetric encryption key
+	secret []byte // the HMAC secret used to calculate the signature
+}
+
+// New creates an AESGCM Crypto handler, generating an encryption key if it is nil or
+// zero length. If hmac_secret isn't specified, the encryption key is used. The key and
+// secret should be 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.
+func New(encryptionKey, hmacSecret []byte) (_ *AESGCM, err error) {
+	if len(encryptionKey) == 0 {
+		if encryptionKey, err = crypto.Random(32); err != nil {
+			return nil, fmt.Errorf("could not generate encryption key: %s", err)
+		}
+	}
+
+	if len(hmacSecret) == 0 {
+		hmacSecret = encryptionKey
+	}
+
+	return &AESGCM{key: encryptionKey, secret: hmacSecret}, nil
+}
+
+// Encrypt a message using the struct key, appending a 12 byte random nonce to the end
+// of the ciphertext message.
+func (c *AESGCM) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
+	block, err := aes.NewCipher(c.key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := crypto.Random(12)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext = aesgcm.Seal(nil, nonce, plaintext, nil)
+	ciphertext = append(ciphertext, nonce...)
+	return ciphertext, nil
+}
+
+// Decrypt a message using the struct key, extracting the nonce from the end.
+func (c *AESGCM) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
+	if len(ciphertext) == 0 {
+		return nil, errors.New("empty cipher text")
+	}
+
+	data := ciphertext[:len(ciphertext)-12]
+	nonce := ciphertext[len(ciphertext)-12:]
+
+	block, err := aes.NewCipher(c.key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err = aesgcm.Open(nil, nonce, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt ciphertext: %s", err)
+	}
+	return plaintext, nil
+}
+
+// EncryptionAlgorithm returns the name of the algorithm for adding to the Transaction.
+func (c *AESGCM) EncryptionAlgorithm() string {
+	return "AES-GCM"
+}
+
+// Sign the specified data (ususally the ciphertext) using the struct secret.
+func (c *AESGCM) Sign(data []byte) (signature []byte, err error) {
+	if len(data) == 0 {
+		return nil, errors.New("cannot sign empty data")
+	}
+
+	hm := hmac.New(sha256.New, c.secret)
+	hm.Write(data)
+	return hm.Sum(nil), nil
+}
+
+// Verify the signature on the specified data using the struct secret.
+func (c *AESGCM) Verify(data, signature []byte) (err error) {
+	hm := hmac.New(sha256.New, c.secret)
+	hm.Write(data)
+
+	if !bytes.Equal(signature, hm.Sum(nil)) {
+		return errors.New("hmac signature mismatch")
+	}
+
+	return nil
+}
+
+// SignatureAlgorithm returns the name of the hmac_algorithm for adding to the Transaction.
+func (c *AESGCM) SignatureAlgorithm() string {
+	return "HMAC"
+}
+
+// EncryptionKey is a read-only getter.
+func (c *AESGCM) EncryptionKey() []byte {
+	return c.key
+}
+
+// HMACSecret is a read-only getter.
+func (c *AESGCM) HMACSecret() []byte {
+	return c.secret
+}

--- a/pkg/trisa/crypto/aesgcm/aesgcm.go
+++ b/pkg/trisa/crypto/aesgcm/aesgcm.go
@@ -65,7 +65,7 @@ func (c *AESGCM) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
 
 // Decrypt a message using the struct key, extracting the nonce from the end.
 func (c *AESGCM) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
-	if len(ciphertext) == 0 {
+	if len(ciphertext) < 12 {
 		return nil, errors.New("empty cipher text")
 	}
 
@@ -91,7 +91,16 @@ func (c *AESGCM) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
 
 // EncryptionAlgorithm returns the name of the algorithm for adding to the Transaction.
 func (c *AESGCM) EncryptionAlgorithm() string {
-	return "AES-GCM"
+	switch len(c.key) {
+	case 32:
+		return "AES256-GCM"
+	case 24:
+		return "AES192-GCM"
+	case 16:
+		return "AES128-GCM"
+	default:
+		return "AES-GCM"
+	}
 }
 
 // Sign the specified data (ususally the ciphertext) using the struct secret.
@@ -119,7 +128,7 @@ func (c *AESGCM) Verify(data, signature []byte) (err error) {
 
 // SignatureAlgorithm returns the name of the hmac_algorithm for adding to the Transaction.
 func (c *AESGCM) SignatureAlgorithm() string {
-	return "HMAC"
+	return "HMAC-SHA256"
 }
 
 // EncryptionKey is a read-only getter.

--- a/pkg/trisa/crypto/aesgcm/aesgcm_test.go
+++ b/pkg/trisa/crypto/aesgcm/aesgcm_test.go
@@ -1,0 +1,37 @@
+package aesgcm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/testnet/pkg/trisa/crypto"
+	"github.com/trisacrypto/testnet/pkg/trisa/crypto/aesgcm"
+)
+
+func TestAESGCM(t *testing.T) {
+	plaintext := []byte("theeaglefliesatmidnight")
+
+	// Generate a key
+	cipher, err := aesgcm.New(nil, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, cipher.EncryptionKey())
+	require.NotEmpty(t, cipher.HMACSecret())
+
+	ciphertext, err := cipher.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	signature, err := cipher.Sign(ciphertext)
+	require.NoError(t, err)
+
+	// Decode using a new cipher
+	var decoder crypto.Crypto
+	decoder, err = aesgcm.New(cipher.EncryptionKey(), cipher.HMACSecret())
+	require.NoError(t, err)
+
+	err = decoder.Verify(ciphertext, signature)
+	require.NoError(t, err)
+
+	decoded, err := decoder.Decrypt(ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decoded)
+}

--- a/pkg/trisa/crypto/crypto.go
+++ b/pkg/trisa/crypto/crypto.go
@@ -1,0 +1,43 @@
+/*
+Package crypto describes interfaces for the various encryption and hmac algorithms that
+might be used to encrypt and sign transaction envelopes being passed securely in the
+TRISA network. Subpackages implement specific algorithms such as aesgcm for symmetric
+encryption or rsa for asymmetric encryption. Note that not all encryption mechanisms are
+legal in different countries, these interfaces allow the use of different algorithms and
+methodologies in the protocol without specifying what must be used.
+*/
+package crypto
+
+import "crypto/rand"
+
+// Crypto handler for TRISA transaction envelopes must be both a Cipher and a Signer.
+type Crypto interface {
+	Cipher
+	Signer
+}
+
+// Cipher is a device that can perform encryption and decryption, This interface wraps
+// different encryption algorithms that must be identified in the TRISA protocol.
+type Cipher interface {
+	Encrypt(plaintext []byte) (ciphertext []byte, err error)
+	Decrypt(ciphertext []byte) (plaintext []byte, err error)
+	EncryptionAlgorithm() string
+}
+
+// Signer creates or verifies HMAC signatures. This interface wraps multiple hmac
+// algorithms that must be identified in the TRISA protocol.
+type Signer interface {
+	Sign(data []byte) (signature []byte, err error)
+	Verify(data, signature []byte) (err error)
+	SignatureAlgorithm() string
+}
+
+// Random generates a secure random sequence of bytes, this helper function is used to
+// easily create keys, salts, and secrets in the crypto subpackages.
+func Random(n int) (b []byte, err error) {
+	b = make([]byte, n)
+	if _, err = rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/pkg/trisa/crypto/rsaoeap/rsaoeap.go
+++ b/pkg/trisa/crypto/rsaoeap/rsaoeap.go
@@ -1,0 +1,54 @@
+package rsaoeap
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"errors"
+)
+
+// RSA implements the crypto.Cipher interface using RSA public/private key algorithm
+// as specified in PKCS #1. Messages are encrypted with the public key and can only be
+// decrypted using the private key. RSA objects must have a public key but the private
+// key is only required for decryption.
+type RSA struct {
+	pub  *rsa.PublicKey
+	priv *rsa.PrivateKey
+}
+
+// New creates an RSA Crypto handler with the specified key pair.
+func New(pub *rsa.PublicKey, priv *rsa.PrivateKey) (_ *RSA, err error) {
+	if pub == nil {
+		return nil, errors.New("a public key is required for RSA operations")
+	}
+	return &RSA{pub: pub, priv: priv}, nil
+}
+
+// Encrypt the message using the public key.
+func (c *RSA) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
+	hash := sha512.New()
+	ciphertext, err = rsa.EncryptOAEP(hash, rand.Reader, c.pub, plaintext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return ciphertext, nil
+}
+
+// Decrypt the message using the private key.
+func (c *RSA) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
+	if c.priv == nil {
+		return nil, errors.New("private key required for decryption")
+	}
+
+	hash := sha512.New()
+	plaintext, err = rsa.DecryptOAEP(hash, rand.Reader, c.priv, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plaintext, nil
+}
+
+// EncryptionAlgorithm returns the name of the algorithm for adding to the Transaction.
+func (c *RSA) EncryptionAlgorithm() string {
+	return "RSA-OAEP-512"
+}

--- a/pkg/trisa/crypto/rsaoeap/rsaoeap.go
+++ b/pkg/trisa/crypto/rsaoeap/rsaoeap.go
@@ -50,5 +50,5 @@ func (c *RSA) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
 
 // EncryptionAlgorithm returns the name of the algorithm for adding to the Transaction.
 func (c *RSA) EncryptionAlgorithm() string {
-	return "RSA-OAEP-512"
+	return "RSA-OAEP-SHA512"
 }

--- a/pkg/trisa/crypto/rsaoeap/rsaoeap_test.go
+++ b/pkg/trisa/crypto/rsaoeap/rsaoeap_test.go
@@ -1,0 +1,34 @@
+package rsaoeap_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/testnet/pkg/trisa/crypto"
+	"github.com/trisacrypto/testnet/pkg/trisa/crypto/rsaoeap"
+)
+
+func TestRSA(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+
+	plaintext := []byte("for your eyes only -- classified")
+
+	// Encrypt using a new cipher with just the public key
+	var cipher crypto.Cipher
+	cipher, err = rsaoeap.New(&priv.PublicKey, nil)
+
+	ciphertext, err := cipher.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	// Decrypt using a new cipher with both public and private key
+	var decoder crypto.Cipher
+	decoder, err = rsaoeap.New(&priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	decoded, err := decoder.Decrypt(ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decoded)
+}


### PR DESCRIPTION
In this PR, I've started transferring over the original TRISA library code with modifications to enable the protocol at both ends and to make it simpler to replace the trisacrypto/trisa repository with this repository. 

So far:

- The trisa/crypto package has been moved over with stronger support for the `Crypto` interface (formerly `Handler`) and breaking out the `Cipher` and `Signer` interfaces for TRISA use. 