### PR TITLE
Demo cleanup websockets

### DIFF
--- a/web/demo/npm/src/App.js
+++ b/web/demo/npm/src/App.js
@@ -60,6 +60,12 @@ class App extends Component {
         let targetVasps = this.state.vasps
             .filter(vasp => vasp.vasp_id !== vaspId)
 
+        if (this.state.originatingVaspStreamingService != null) {
+            this.state.originatingVaspStreamingService.close()
+        }
+        if (this.state.beneficiaryVaspStreamingService != null) {
+            this.state.beneficiaryVaspStreamingService.close()
+        }
         this.setState({
             selectedOriginatingVasp: selectedVasp,
             selectedBeneficiaryVasp: null,
@@ -78,6 +84,12 @@ class App extends Component {
     }
 
     onOriginatingVaspCleared = () => {
+        if (this.state.originatingVaspStreamingService != null) {
+            this.state.originatingVaspStreamingService.close()
+        }
+        if (this.state.beneficiaryVaspStreamingService != null) {
+            this.state.beneficiaryVaspStreamingService.close()
+        }
         this.setState({
             selectedOriginatingVasp: null,
             selectedBeneficiaryVasp: null,
@@ -94,6 +106,9 @@ class App extends Component {
             .filter(vasp => vasp.vasp_id === vaspId)[0]
 
         console.log("Selected beneficiary vasp " + JSON.stringify(selectedVasp))
+        if (this.state.beneficiaryVaspStreamingService != null) {
+            this.state.beneficiaryVaspStreamingService.close()
+        }
         this.setState({
             selectedBeneficiaryVasp: selectedVasp,
             beneficiaryVaspStreamingService: new VaspStreamingService({'vasp_id': selectedVasp.vasp_id, 'context_id': this.sessionId, originator: false}, 'https://demo.bob.vaspbot.net')
@@ -101,6 +116,9 @@ class App extends Component {
     }
 
     onBeneficiaryVaspCleared = () => {
+        if (this.state.beneficiaryVaspStreamingService != null) {
+            this.state.beneficiaryVaspStreamingService.close()
+        }
         this.setState({
             selectedBeneficiaryVasp: null,
             beneficiaryVaspStreamingService: null

--- a/web/demo/npm/src/services/VaspStreamingService.ts
+++ b/web/demo/npm/src/services/VaspStreamingService.ts
@@ -28,6 +28,10 @@ export class VaspStreamingService {
         this.setupWebsocket()
     }
 
+    close() {
+        this.webSocket.close()
+    }
+
     setupWebsocket() {
         this.webSocket.on('connect', () => {
             console.log('socket connected');


### PR DESCRIPTION
Resolve issues with websockets not being cleared properly (and thus RVASP GRPC stream not being closed) after being cleared from the demo UI.
Also generates a new uuid for client name whenever an RVASP API instance is created 