### PR TITLE
trisatest.net docs redirect to trisa.dev

### DIFF
--- a/containers/docs-redirect/Dockerfile
+++ b/containers/docs-redirect/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:stable
+
+LABEL maintainer="TRISA <admin@trisa.io>"
+LABEL description="Redirect trisatest.net to trisa.dev"
+
+COPY containers/docs-redirect/nginx.conf /etc/nginx/conf.d/default.conf
+
+ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
+CMD [ "nginx", "-g", "daemon off;" ]

--- a/containers/docs-redirect/nginx.conf
+++ b/containers/docs-redirect/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    server_name _;
+
+    rewrite ^/$ https://trisa.dev permanent;
+    rewrite ^/(.*)$ https://trisa.dev/$1 permanent;
+}

--- a/manifests/docs.yaml
+++ b/manifests/docs.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: docs
-        image: trisa/testnet-docs:b7f39e7
+        image: trisa/docs-redirect:latest
         ports:
         - containerPort: 80
           protocol: TCP

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -37,6 +37,10 @@ build:
       alias: BASE
     docker:
       dockerfile: containers/rvasp/evil/Dockerfile
+  - image: trisa/docs-redirect
+    context: .
+    docker:
+      dockerfile: containers/docs-redirect/Dockerfile
   local:
     push: true
     useDockerCLI: true


### PR DESCRIPTION
Implements an nginx Docker container that permanently redirects everything to trisa.dev and includes any paths in the redirect via rewrite rules. Sort of a heavyweight way to redirect, but effective and easy to deploy. 