### PR TITLE
sc-5110 Add database reset job

### DIFF
--- a/containers/db/reset/Dockerfile
+++ b/containers/db/reset/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.16-buster AS builder
+WORKDIR /rvasp/build
+COPY . .
+RUN go test ./... && go build -v ./cmd/rvasp
+
+FROM ubuntu:focal
+LABEL maintainer="TRISA <info@trisa.io>"
+LABEL description="Job to reset the Robot VASP working database"
+RUN apt-get update && apt-get install -y postgresql-client
+COPY --from=builder /rvasp/build/rvasp /bin/
+COPY --from=builder /rvasp/build/scripts/reset-db.sh /bin/
+COPY --from=builder /rvasp/build/pkg/rvasp/fixtures /fixtures
+
+CMD ["/bin/reset-db.sh"]

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Drop the existing tables
+psql -d $RVASP_DATABASE -c "SELECT 'DROP TABLE IF EXISTS ' || tablename || ' CASCADE;' FROM pg_tables;"
+
+# Initialize the database with the fixtures
+/bin/rvasp initdb


### PR DESCRIPTION
This adds a database reset job that can be run as a Docker container. It requires at least two environment variables to be passed into the container: `RVASP_DATABASE` which is the dsn pointing to the running postgres database and `RVASP_FIXTURES_PATH` which is the path to the database fixtures (should be set to `/fixtures`).