### PR TITLE
sc-5118 originator policy decisions

### DIFF
--- a/pkg/rvasp/db/db.go
+++ b/pkg/rvasp/db/db.go
@@ -83,8 +83,8 @@ func (d *DB) LookupPending() *gorm.DB {
 }
 
 // LookupWallet by wallet address.
-func (d *DB) LookupWallet(walletAddress string) *gorm.DB {
-	return d.Query().Where("address = ?", walletAddress)
+func (d *DB) LookupWallet(address string) *gorm.DB {
+	return d.Query().Where("address = ?", address)
 }
 
 // VASP is a record of known partner VASPs and caches TRISA protocol information. This
@@ -119,7 +119,7 @@ const (
 )
 
 // Returns True if this is a valid policy
-func isPolicy(policy PolicyType) bool {
+func isValidPolicy(policy PolicyType) bool {
 	return policy == BasicSync || policy == PartialSync || policy == FullAsync || policy == RejectedAsync
 }
 

--- a/pkg/rvasp/db/db.go
+++ b/pkg/rvasp/db/db.go
@@ -72,7 +72,7 @@ func (d *DB) LookupBeneficiary(beneficiary string) *gorm.DB {
 	return d.Query().Preload("Provider").Where("email = ?", beneficiary).Or("address = ?", beneficiary)
 }
 
-// LookupIdentity by email address and provider.
+// LookupIdentity by wallet address.
 func (d *DB) LookupIdentity(walletAddress string) *gorm.DB {
 	return d.Query().Where("wallet_address = ?", walletAddress)
 }
@@ -80,6 +80,11 @@ func (d *DB) LookupIdentity(walletAddress string) *gorm.DB {
 // LookupPending returns the pending transactions.
 func (d *DB) LookupPending() *gorm.DB {
 	return d.Query().Where("state = ?", TransactionPending)
+}
+
+// LookupWallet by wallet address.
+func (d *DB) LookupWallet(walletAddress string) *gorm.DB {
+	return d.Query().Where("address = ?", walletAddress)
 }
 
 // VASP is a record of known partner VASPs and caches TRISA protocol information. This
@@ -104,16 +109,31 @@ func (VASP) TableName() string {
 	return "vasps"
 }
 
+type PolicyType string
+
+const (
+	BasicSync     PolicyType = "basic_sync"
+	PartialSync   PolicyType = "partial_sync"
+	FullAsync     PolicyType = "full_async"
+	RejectedAsync PolicyType = "rejected_async"
+)
+
+// Returns True if this is a valid policy
+func isPolicy(policy PolicyType) bool {
+	return policy == BasicSync || policy == PartialSync || policy == FullAsync || policy == RejectedAsync
+}
+
 // Wallet is a mapping of wallet IDs to VASPs to determine where to send transactions.
 // Provider lookups can happen by wallet address or by email.
 type Wallet struct {
 	gorm.Model
-	Address    string `gorm:"uniqueIndex"`
-	Email      string `gorm:"uniqueIndex"`
-	ProviderID uint   `gorm:"not null"`
-	Provider   VASP   `gorm:"foreignKey:ProviderID"`
-	VaspID     uint   `gorm:"not null"`
-	Vasp       VASP   `gorm:"foreignKey:VaspID"`
+	Address    string     `gorm:"uniqueIndex"`
+	Email      string     `gorm:"uniqueIndex"`
+	Policy     PolicyType `gorm:"column:policy"`
+	ProviderID uint       `gorm:"not null"`
+	Provider   VASP       `gorm:"foreignKey:ProviderID"`
+	VaspID     uint       `gorm:"not null"`
+	Vasp       VASP       `gorm:"foreignKey:VaspID"`
 }
 
 // TableName explicitly defines the name of the table for the model

--- a/pkg/rvasp/db/db_test.go
+++ b/pkg/rvasp/db/db_test.go
@@ -147,6 +147,21 @@ func (s *dbTestSuite) TestLookupIdentity() {
 	require.Equal(id, identity.ID)
 }
 
+func (s *dbTestSuite) TestLookupWallet() {
+	require := s.Require()
+	address := "18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh"
+	id := s.db.GetVASP().ID
+
+	// Wallet lookups should be limited to the configured VASP
+	query := regexp.QuoteMeta(`SELECT * FROM "wallets" WHERE vasp_id = $1 AND address = $2`)
+	s.mock.ExpectQuery(query).WithArgs(id, address).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(id))
+
+	var wallet db.Wallet
+	tx := s.db.LookupWallet(address).First(&wallet)
+	require.NoError(tx.Error)
+	require.Equal(id, wallet.ID)
+}
+
 func (s *dbTestSuite) TestTransactions() {
 	require := s.Require()
 	email := "mary@alicevasp.us"

--- a/pkg/rvasp/db/fixtures.go
+++ b/pkg/rvasp/db/fixtures.go
@@ -138,24 +138,37 @@ func LoadWallets(fixturesPath string) (wallets []Wallet, accounts []Account, err
 		w := Wallet{}
 		a := Account{}
 
-		// Parse the wallet info
-		if len(record.([]interface{})) < 4 {
+		// Validate wallet record
+		var fields []interface{}
+		var ok bool
+		if fields, ok = record.([]interface{}); !ok {
 			return nil, nil, fmt.Errorf("could not parse wallet record: %v", record)
 		}
 
-		w.Address = record.([]interface{})[0].(string)
-		w.Email = record.([]interface{})[1].(string)
-		w.ProviderID = uint(record.([]interface{})[2].(float64))
+		// Validate the number of fields
+		if len(fields) < 5 {
+			return nil, nil, fmt.Errorf("invalid number of wallet fields: got %d, expected 5", len(fields))
+		}
+
+		// Parse the wallet fields
+		w.Address = fields[0].(string)
+		w.Email = fields[1].(string)
+		w.ProviderID = uint(fields[2].(float64))
 		w.VaspID = w.ProviderID
 
 		a.Email = w.Email
 		a.WalletAddress = w.Address
 		a.VaspID = w.ProviderID
 
+		// Validate the policy field
+		w.Policy = PolicyType(fields[3].(string))
+		if !isPolicy(w.Policy) {
+			return nil, nil, fmt.Errorf("invalid policy for wallet %s: %s", w.Address, w.Policy)
+		}
+
 		// Parse the account name
 		var person map[string]interface{}
-		var ok bool
-		if person, ok = record.([]interface{})[3].(map[string]interface{}); !ok {
+		if person, ok = fields[4].(map[string]interface{}); !ok {
 			return nil, nil, fmt.Errorf("could not parse person record: %v", record)
 		}
 		var name_ids interface{}

--- a/pkg/rvasp/db/fixtures.go
+++ b/pkg/rvasp/db/fixtures.go
@@ -146,7 +146,7 @@ func LoadWallets(fixturesPath string) (wallets []Wallet, accounts []Account, err
 		}
 
 		// Validate the number of fields
-		if len(fields) < 5 {
+		if len(fields) != 5 {
 			return nil, nil, fmt.Errorf("invalid number of wallet fields: got %d, expected 5", len(fields))
 		}
 
@@ -162,7 +162,7 @@ func LoadWallets(fixturesPath string) (wallets []Wallet, accounts []Account, err
 
 		// Validate the policy field
 		w.Policy = PolicyType(fields[3].(string))
-		if !isPolicy(w.Policy) {
+		if !isValidPolicy(w.Policy) {
 			return nil, nil, fmt.Errorf("invalid policy for wallet %s: %s", w.Address, w.Policy)
 		}
 

--- a/pkg/rvasp/fixtures/wallets.json
+++ b/pkg/rvasp/fixtures/wallets.json
@@ -1,7 +1,9 @@
 [
     [
         "18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh",
-        "robert@bobvasp.co.uk", 1,
+        "robert@bobvasp.co.uk",
+        1,
+        "basic_sync",
         {
             "natural_person": {
                 "name": {
@@ -36,7 +38,9 @@
     ],
     [
         "1LgtLYkpaXhHDu1Ngh7x9fcBs5KuThbSzw",
-        "george@bobvasp.co.uk", 1,
+        "george@bobvasp.co.uk",
+        1,
+        "partial_sync",
         {
             "natural_person": {
                 "name": {
@@ -71,7 +75,9 @@
     ],
     [
         "14WU745djqecaJ1gmtWQGeMCFim1W5MNp3",
-        "larry@bobvasp.co.uk", 1,
+        "larry@bobvasp.co.uk",
+        1,
+        "full_async",
         {
             "natural_person": {
                 "name": {
@@ -110,7 +116,9 @@
     ],
     [
         "1Hzej6a2VG7C8iCAD5DAdN72cZH5THSMt9",
-        "fred@bobvasp.co.uk", 1,
+        "fred@bobvasp.co.uk",
+        1,
+        "rejected_async",
         {
             "natural_person": {
                 "name": {
@@ -149,7 +157,9 @@
     ],
     [
        "1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX",
-       "mary@alicevasp.us", 2,
+       "mary@alicevasp.us",
+       2,
+       "basic_sync",
         {
             "natural_person": {
                 "name": {
@@ -189,7 +199,9 @@
     ],
     [
         "1MRCxvEpBoY8qajrmNTSrcfXSZ2wsrGeha",
-        "alice@alicevasp.us", 2,
+        "alice@alicevasp.us",
+        2,
+        "partial_sync",
         {
             "natural_person": {
                 "name": {
@@ -225,7 +237,9 @@
     ],
     [
         "14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v",
-        "jane@alicevasp.us", 2,
+        "jane@alicevasp.us",
+        2,
+        "full_async",
         {
             "natural_person": {
                 "name": {
@@ -261,7 +275,9 @@
     ],
     [
         "19nFejdNSUhzkAAdwAvP3wc53o8dL326QQ",
-        "sarah@alicevasp.us", 2,
+        "sarah@alicevasp.us",
+        2,
+        "rejected_async",
         {
             "natural_person": {
                 "name": {
@@ -297,7 +313,9 @@
     ],
     [
         "1PFTsUQrRqvmFkJunfuQbSC2k9p4RfxYLF",
-        "voldemort@evilvasp.gg", 3,
+        "voldemort@evilvasp.gg",
+        3,
+        "basic_sync",
         {
             "natural_person": {
                 "name": {
@@ -335,7 +353,9 @@
     ],
     [
         "172n89jLjXKmFJni1vwV5EzxKRXuAAoxUz",
-        "launderer@evilvasp.gg", 3,
+        "launderer@evilvasp.gg",
+        3,
+        "partial_sync",
         {
             "natural_person": {
                 "name": {
@@ -374,7 +394,9 @@
     ],
     [
         "182kF4mb5SW4KGEvBSbyXTpDWy8rK1Dpu",
-        "badnews@evilvasp.gg", 3,
+        "badnews@evilvasp.gg",
+        3,
+        "full_async",
         {
             "natural_person": {
                 "name": {
@@ -410,7 +432,9 @@
     ],
     [
         "1AsF1fMSaXPzz3dkBPyq81wrPQUKtT2tiz",
-        "gambler@evilvasp.gg", 3,
+        "gambler@evilvasp.gg",
+        3,
+        "rejected_async",
         {
             "natural_person": {
                 "name": {

--- a/pkg/rvasp/rvasp.go
+++ b/pkg/rvasp/rvasp.go
@@ -195,7 +195,7 @@ func (s *Server) Transfer(ctx context.Context, req *pb.TransferRequest) (*pb.Tra
 	case db.RejectedAsync:
 		return s.rejectedAsyncTransfer(req, account)
 	default:
-		return nil, status.Errorf(codes.FailedPrecondition, "unknown policy %s for wallet: %s", policy, account.Wallet.Address)
+		return nil, status.Errorf(codes.FailedPrecondition, "unknown policy '%s' for wallet '%s'", policy, account.Wallet.Address)
 	}
 }
 


### PR DESCRIPTION
This implements the policy decisions for the originator side by storing the configured policies in the `wallets` table, and calling the appropriate handler based on the wallet lookup at the beginning of `Transfer`.