### PR TITLE
sc-5119 Add beneficiary policy decisions

### DIFF
--- a/pkg/rvasp/trisa.go
+++ b/pkg/rvasp/trisa.go
@@ -302,7 +302,7 @@ func (s *TRISA) handleTransaction(ctx context.Context, peer *peers.Peer, in *pro
 	case db.RejectedAsync:
 		return s.rejectedAsyncTransfer(in, peer, identity, transaction, account)
 	default:
-		return nil, protocol.Errorf(protocol.InternalError, "unknown policy %s for wallet: %s", policy, account.WalletAddress)
+		return nil, protocol.Errorf(protocol.InternalError, "unknown policy '%s' for wallet '%s'", policy, account.WalletAddress)
 	}
 }
 


### PR DESCRIPTION
This adds policy decisions for the beneficiary rVASP similar to what was just done for the originator, so that the beneficiary executes the appropriate scenario depending on the beneficiary wallet address specified in the transaction.