### PR TITLE
sc-5937 fix GDS connection issue

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
       - RVASP_GDS_URL=gds:4433
+      - RVASP_GDS_INSECURE=true
       - RVASP_DATABASE_MAX_RETRIES=5
       - RVASP_ASYNC_INTERVAL
       - RVASP_ASYNC_NOT_BEFORE
@@ -85,6 +86,7 @@ services:
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
       - RVASP_GDS_URL=gds:4433
+      - RVASP_GDS_INSECURE=true
       - RVASP_DATABASE_MAX_RETRIES=5
       - RVASP_ASYNC_INTERVAL
       - RVASP_ASYNC_NOT_BEFORE
@@ -106,6 +108,7 @@ services:
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
       - RVASP_GDS_URL=gds:4433
+      - RVASP_GDS_INSECURE=true
       - RVASP_DATABASE_MAX_RETRIES=5
       - RVASP_ASYNC_INTERVAL
       - RVASP_ASYNC_NOT_BEFORE

--- a/pkg/rvasp/config/config.go
+++ b/pkg/rvasp/config/config.go
@@ -31,7 +31,8 @@ type Config struct {
 
 // GDSConfig is the configuration for connecting to GDS
 type GDSConfig struct {
-	URL string `split_words:"true" default:"api.trisatest.net:443"`
+	URL      string `split_words:"true" default:"api.trisatest.net:443"`
+	Insecure bool   `split_words:"true" default:"false"`
 }
 
 // DatabaseConfig is the configuration for connecting to the RVASP database

--- a/pkg/rvasp/rvasp.go
+++ b/pkg/rvasp/rvasp.go
@@ -79,7 +79,11 @@ func New(conf *config.Config) (s *Server, err error) {
 
 	// Create the remote peers using the same credentials as the TRISA service
 	s.peers = peers.New(s.trisa.certs, s.trisa.chain, s.conf.GDS.URL)
-	s.peers.Connect(grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// Connect to GDS without credentials if insecure is set
+	if s.conf.GDS.Insecure {
+		s.peers.Connect(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
 	s.updates = NewUpdateManager()
 	return s, nil
 }


### PR DESCRIPTION
This should fix the GDS connection issue by adding an insecure connection flag which defaults to false so we can still use a local GDS for local development.