### PR TITLE
sc-5933 Marshal transaction

### DIFF
--- a/pkg/rvasp/db/db.go
+++ b/pkg/rvasp/db/db.go
@@ -250,7 +250,6 @@ func (Account) TableName() string {
 // TODO: Add a field for the transaction payload marshaled as a string.
 type Transaction struct {
 	gorm.Model
-	TxID          string              `gorm:"not null"`
 	Envelope      string              `gorm:"not null"`
 	AccountID     uint                `gorm:"not null"`
 	Account       Account             `gorm:"foreignKey:AccountID"`
@@ -258,13 +257,14 @@ type Transaction struct {
 	Originator    Identity            `gorm:"foreignKey:OriginatorID"`
 	BeneficiaryID uint                `gorm:"column:beneficiary_id;not null"`
 	Beneficiary   Identity            `gorm:"foreignKey:BeneficiaryID"`
-	Amount        decimal.Decimal     `gorm:"type:numeric(15,2)"`
+	Amount        decimal.Decimal     `gorm:"type:decimal(15,8)"`
 	Debit         bool                `gorm:"not null"`
 	State         pb.TransactionState `gorm:"not null;default:0"`
 	Timestamp     time.Time           `gorm:"not null"`
 	NotBefore     time.Time           `gorm:"not null"`
 	NotAfter      time.Time           `gorm:"not null"`
 	Identity      string              `gorm:"not null"`
+	Transaction   string              `gorm:"not null"`
 	VaspID        uint                `gorm:"not null"`
 	Vasp          VASP                `gorm:"foreignKey:VaspID"`
 }

--- a/pkg/rvasp/fixtures/wallets.json
+++ b/pkg/rvasp/fixtures/wallets.json
@@ -407,7 +407,7 @@
         "badnews@evilvasp.gg",
         3,
         "SendFull",
-        "SyncRequire",
+        "AsyncRepair",
         {
             "natural_person": {
                 "name": {

--- a/pkg/rvasp/rvasp.go
+++ b/pkg/rvasp/rvasp.go
@@ -524,8 +524,7 @@ func (s *Server) respondAsync(peer *peers.Peer, payload *protocol.Payload, ident
 	switch xfer.State {
 	case pb.TransactionState_AWAITING:
 		// Fill the transaction with a new TxID to continue the handshake
-		xfer.TxID = uuid.New().String()
-		transaction.Txid = xfer.TxID
+		transaction.Txid = uuid.New().String()
 		if payload, err = createTransferPayload(identity, transaction); err != nil {
 			log.Error().Err(err).Msg("could not create transfer payload")
 			return nil, protocol.Errorf(protocol.InternalError, "could not create transfer payload: %s", err)
@@ -577,6 +576,13 @@ func (s *Server) respondAsync(peer *peers.Peer, payload *protocol.Payload, ident
 			return nil, status.Errorf(codes.Internal, "could not marshal IVMS 101 identity: %s", err)
 		}
 		xfer.Identity = string(data)
+
+		// Update the transaction with the new generic.Transaction
+		if data, err = json.Marshal(transaction); err != nil {
+			log.Error().Err(err).Msg("could not marshal generic.Transaction")
+			return nil, status.Errorf(codes.Internal, "could not marshal generic.Transaction: %s", err)
+		}
+		xfer.Transaction = string(data)
 
 		// Update the Transaction in the database with the pending timestamps
 		if xfer.NotBefore, err = time.Parse(time.RFC3339, pending.ReplyNotBefore); err != nil {

--- a/scripts/rvasp-test.sh
+++ b/scripts/rvasp-test.sh
@@ -1,113 +1,121 @@
 #!/bin/bash
 # TODO: check codes
 
+if [ "$1" == "--local" ]; then
+    ALICE_ENDPOINT=localhost:5434
+    BOB_ENDPOINT=localhost:6434
+else
+    ALICE_ENDPOINT=admin.alice.vaspbot.net:443
+    BOB_ENDPOINT=admin.bob.vaspbot.net:443
+fi
+
 # Send from Alice to Bob
 # Partial Sync Repair: success expected
 echo "Alice --> Bob Partial Sync Repair"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX -d 0.0001 \
     -b 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh
 
 # Partial Sync Require: rejection expected
 echo "Alice --> Bob Partial Sync Require"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX -d 0.0002 \
     -b 1LgtLYkpaXhHDu1Ngh7x9fcBs5KuThbSzw
 
 # Full Sync Repair: success expected
 echo "Alice --> Bob Full Sync Repair"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1MRCxvEpBoY8qajrmNTSrcfXSZ2wsrGeha -d 0.0003 \
     -b 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh
 
 # Full Sync Require: success expected
 echo "Alice --> Bob Full Sync Require"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v -d 0.0004 \
     -b 1LgtLYkpaXhHDu1Ngh7x9fcBs5KuThbSzw
 
 # Partial Async Repair: success expected
 # TODO: how to test getting a message back?
 echo "Alice --> Bob Partial Async Repair"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX -d 0.0005 \
     -b 14WU745djqecaJ1gmtWQGeMCFim1W5MNp3
 
 # Partial Async Reject: rejection expected
 echo "Alice --> Bob Partial Async Reject"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX -d 0.0006 \
     -b 1Hzej6a2VG7C8iCAD5DAdN72cZH5THSMt9
 
 # Full Async Repair: success expected
 echo "Alice --> Bob Full Async Repair"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 1MRCxvEpBoY8qajrmNTSrcfXSZ2wsrGeha -d 0.0007 \
     -b 14WU745djqecaJ1gmtWQGeMCFim1W5MNp3
 
 # Full Async Require: reject expected
 echo "Alice --> Bob Full Async Reject"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v -d 0.0008 \
     -b 1Hzej6a2VG7C8iCAD5DAdN72cZH5THSMt9
 
 # Send Error: rejection expected.
 echo "Alice --> Bob Send Error"
-rvasp transfer -e admin.alice.vaspbot.net:443 \
+rvasp transfer -e $ALICE_ENDPOINT \
     -a 19nFejdNSUhzkAAdwAvP3wc53o8dL326QQ -d 0.0009 \
     -b 1Hzej6a2VG7C8iCAD5DAdN72cZH5THSMt9
 
 # Send from Bob to Alice
 # Partial Sync Repair: success expected
 echo "Bob --> Alice Partial Sync Repair"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh -d 0.00010 \
     -b 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX
 
 # Partial Sync Require: rejection expected
 echo "Bob --> Alice Partial Sync Require"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh -d 0.00011 \
     -b 1MRCxvEpBoY8qajrmNTSrcfXSZ2wsrGeha
 
 # Full Sync Repair: success expected
 echo "Bob --> Alice Full Sync Repair"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 1LgtLYkpaXhHDu1Ngh7x9fcBs5KuThbSzw -d 0.00012 \
     -b 1ASkqdo1hvydosVRvRv2j6eNnWpWLHucMX
 
 # Full Sync Require: success expected
 echo "Bob --> Alice Full Sync Require"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 14WU745djqecaJ1gmtWQGeMCFim1W5MNp3 -d 0.00013 \
     -b 1MRCxvEpBoY8qajrmNTSrcfXSZ2wsrGeha
 
 # Partial Async Repair: success expected
 echo "Bob --> Alice Partial Async Repair"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh -d 0.00014 \
     -b 14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v
 
 # Partial Async Require: rejection expected
 echo "Bob --> Alice Partial Async Reject"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 18nxAxBktHZDrMoJ3N2fk9imLX8xNnYbNh -d 0.00015 \
     -b 19nFejdNSUhzkAAdwAvP3wc53o8dL326QQ
 
 # Full Async Repair: success expected
 echo "Bob --> Alice Full Async Repair"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 1LgtLYkpaXhHDu1Ngh7x9fcBs5KuThbSzw -d 0.00016 \
     -b 14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v
 
 # Full Async Require: rejection expected
 echo "Bob --> Alice Full Async Reject"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 14WU745djqecaJ1gmtWQGeMCFim1W5MNp3 -d 0.00017 \
     -b 19nFejdNSUhzkAAdwAvP3wc53o8dL326QQ
 
 # Send Error: rejection expected.
 echo "Bob --> Alice Send Error"
-rvasp transfer -e admin.bob.vaspbot.net:443 \
+rvasp transfer -e $BOB_ENDPOINT \
     -a 1Hzej6a2VG7C8iCAD5DAdN72cZH5THSMt9 -d 0.00018 \
     -b 14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v


### PR DESCRIPTION
This marshals the `generic.Transaction` payload as a string to the database in a similar manner to how we're handling the identity payload. This allows us to avoid having to reconstruct the payload for async transactions so the rvasps can act a bit more consistent. I also discovered some bugs in local testing which I've taken the opportunity to fix.