### PR TITLE
SC-7143 endpoint lookup and error handling

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - RVASP_FIXTURES_PATH=/fixtures
       - RVASP_DATABASE_MAX_RETRIES=5
     volumes:
-      - ../pkg/rvasp/fixtures:/fixtures
+      - ../fixtures/rvasps:/fixtures
 
   gds:
     image: trisa/gds:latest
@@ -59,7 +59,7 @@ services:
       - 5434:4434
       - 5435:4435
     environment:
-      - RVASP_NAME=api.alice.vaspbot.net
+      - RVASP_NAME=alice
       - RVASP_DATABASE_DSN=postgres://postgres:postgres@db:5432/rvasp?sslmode=disable
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
@@ -83,7 +83,7 @@ services:
       - 6434:4434
       - 6435:4435
     environment:
-      - RVASP_NAME=api.bob.vaspbot.net
+      - RVASP_NAME=bob
       - RVASP_DATABASE_DSN=postgres://postgres:postgres@db:5432/rvasp?sslmode=disable
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
@@ -107,7 +107,7 @@ services:
       - 7434:4434
       - 7435:4435
     environment:
-      - RVASP_NAME=api.evil.vaspbot.net
+      - RVASP_NAME=evil
       - RVASP_DATABASE_DSN=postgres://postgres:postgres@db:5432/rvasp?sslmode=disable
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem
@@ -131,7 +131,7 @@ services:
       - 8434:4434
       - 8435:4435
     environment:
-      - RVASP_NAME=api.charlie.vaspbot.net
+      - RVASP_NAME=charlie
       - RVASP_DATABASE_DSN=postgres://postgres:postgres@db:5432/rvasp?sslmode=disable
       - RVASP_CERT_PATH=/certs/cert.pem
       - RVASP_TRUST_CHAIN_PATH=/certs/cert.pem

--- a/pkg/rvasp/mock.go
+++ b/pkg/rvasp/mock.go
@@ -34,6 +34,7 @@ func NewTRISAMock(conf *config.Config) (s *TRISA, remotePeers *peers.Peers, mock
 	remotePeers = peers.NewMock(s.certs, s.chain, conf.GDS.URL)
 	remotePeers.Add(&peers.PeerInfo{
 		CommonName: "alice",
+		Endpoint:   "gds.example.io:443",
 		SigningKey: &s.sign.PublicKey,
 	})
 	parent.peers = remotePeers

--- a/pkg/rvasp/peer.go
+++ b/pkg/rvasp/peer.go
@@ -1,0 +1,77 @@
+package rvasp
+
+import (
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/trisa/pkg/trisa/peers"
+)
+
+// TODO: The peers cache needs to be flushed periodically to prevent the situation
+// where remote peers change their endpoints or certificates and the rVASPs are stuck
+// using the old info.
+
+// fetchPeer returns the peer with the common name from the cache and performs a lookup
+// against the directory service if the peer does not have an endpoint.
+func (s *Server) fetchPeer(commonName string) (peer *peers.Peer, err error) {
+	// Retrieve or create the peer from the cache
+	if peer, err = s.peers.Get(commonName); err != nil {
+		log.Error().Err(err).Msg("could not create or fetch peer")
+		return nil, fmt.Errorf("could not create or fetch peer: %s", err)
+	}
+
+	// Ensure that the remote peer has an endpoint to connect to
+	if err = s.checkEndpoint(peer); err != nil {
+		log.Warn().Err(err).Msg("could not fetch endpoint from remote peer")
+		return nil, fmt.Errorf("could not fetch endpoint from remote peer: %s", err)
+	}
+
+	return peer, nil
+}
+
+// fetchSigningKey returns the signing key for the peer, performing an endpoint lookup
+// and key exchange if necessary.
+func (s *Server) fetchSigningKey(peer *peers.Peer) (key *rsa.PublicKey, err error) {
+	// Ensure that the remote peer has an endpoint to connect to
+	if err = s.checkEndpoint(peer); err != nil {
+		log.Warn().Err(err).Msg("could not fetch endpoint from remote peer")
+		return nil, fmt.Errorf("could not fetch endpoint from remote peer: %s", err)
+	}
+
+	if peer.SigningKey() == nil {
+		// If no key is available, perform a key exchange with the remote peer
+		if peer.ExchangeKeys(true); err != nil {
+			log.Warn().Str("common_name", peer.String()).Err(err).Msg("could not exchange keys with remote peer")
+			return nil, fmt.Errorf("could not exchange keys with remote peer: %s", err)
+		}
+
+		// Verify the key is now available on the peer
+		if peer.SigningKey() == nil {
+			log.Error().Str("common_name", peer.String()).Msg("peer has no key after key exchange")
+			return nil, fmt.Errorf("peer has no key after key exchange")
+		}
+	}
+
+	return peer.SigningKey(), nil
+}
+
+// checkEndpoint ensures that the peer has an endpoint to connect to, and performs a
+// lookup against the directory service if it does not.
+func (s *Server) checkEndpoint(peer *peers.Peer) (err error) {
+	// If the endpoint is not in the peer, do the lookup to fetch the endpoint
+	if peer.Info().Endpoint == "" {
+		var remote *peers.Peer
+		if remote, err = s.peers.Lookup(peer.String()); err != nil {
+			log.Warn().Str("peer", peer.String()).Err(err).Msg("could not lookup peer")
+			return fmt.Errorf("could not lookup peer: %s", err)
+		}
+
+		if remote.Info().Endpoint == "" {
+			log.Error().Str("peer", peer.String()).Msg("peer has no endpoint after lookup")
+			return fmt.Errorf("peer has no endpoint after lookup")
+		}
+		peer = remote
+	}
+	return nil
+}

--- a/pkg/rvasp/peer.go
+++ b/pkg/rvasp/peer.go
@@ -22,7 +22,7 @@ func (s *Server) fetchPeer(commonName string) (peer *peers.Peer, err error) {
 	}
 
 	// Ensure that the remote peer has an endpoint to connect to
-	if err = s.checkEndpoint(peer); err != nil {
+	if err = s.resolveEndpoint(peer); err != nil {
 		log.Warn().Err(err).Msg("could not fetch endpoint from remote peer")
 		return nil, fmt.Errorf("could not fetch endpoint from remote peer: %s", err)
 	}
@@ -34,7 +34,7 @@ func (s *Server) fetchPeer(commonName string) (peer *peers.Peer, err error) {
 // and key exchange if necessary.
 func (s *Server) fetchSigningKey(peer *peers.Peer) (key *rsa.PublicKey, err error) {
 	// Ensure that the remote peer has an endpoint to connect to
-	if err = s.checkEndpoint(peer); err != nil {
+	if err = s.resolveEndpoint(peer); err != nil {
 		log.Warn().Err(err).Msg("could not fetch endpoint from remote peer")
 		return nil, fmt.Errorf("could not fetch endpoint from remote peer: %s", err)
 	}
@@ -56,9 +56,9 @@ func (s *Server) fetchSigningKey(peer *peers.Peer) (key *rsa.PublicKey, err erro
 	return peer.SigningKey(), nil
 }
 
-// checkEndpoint ensures that the peer has an endpoint to connect to, and performs a
-// lookup against the directory service if it does not.
-func (s *Server) checkEndpoint(peer *peers.Peer) (err error) {
+// resolveEndpoint ensures that the peer has an endpoint to connect to, and performs a
+// lookup against the directory service to set the endpoint on the peer if necessary.
+func (s *Server) resolveEndpoint(peer *peers.Peer) (err error) {
 	// If the endpoint is not in the peer, do the lookup to fetch the endpoint
 	if peer.Info().Endpoint == "" {
 		var remote *peers.Peer

--- a/pkg/rvasp/peer.go
+++ b/pkg/rvasp/peer.go
@@ -71,7 +71,6 @@ func (s *Server) checkEndpoint(peer *peers.Peer) (err error) {
 			log.Error().Str("peer", peer.String()).Msg("peer has no endpoint after lookup")
 			return fmt.Errorf("peer has no endpoint after lookup")
 		}
-		peer = remote
 	}
 	return nil
 }

--- a/pkg/rvasp/trisa_test.go
+++ b/pkg/rvasp/trisa_test.go
@@ -147,6 +147,11 @@ func (s *rVASPTestSuite) TestValidTransfer() {
 	require.NoError(err)
 	require.NotNil(response)
 
+	// Verify that a valid envelope was returned
+	reject, isErr := envelope.Check(response)
+	require.Nil(reject)
+	require.False(isErr)
+
 	// Decrypt the response envelope
 	payload, reject, err = envelope.Open(response, envelope.WithRSAPrivateKey(key))
 	require.NoError(err)

--- a/scripts/fixtures/gds-fixture.py
+++ b/scripts/fixtures/gds-fixture.py
@@ -1,19 +1,26 @@
+import pem
 import json
+import base64
 import argparse
 
-def generate_fixtures(template_path, output_path, name, person, id, endpoint):
-    # Load the template JSON
-    with open(template_path, 'r') as template_file:
+def generate_fixtures(args):
+    # Load the GDS template JSON
+    with open(args.template, 'r') as template_file:
         template = json.load(template_file)
     
     # Insert the name, id, and TRISA endpoint into the template
-    template['common_name'] = name
-    template['entity']['name']['name_identifiers'][0]['legal_person_name'] = person
-    template['id'] = id
-    template['trisa_endpoint'] = endpoint
+    template['common_name'] = args.name
+    template['entity']['name']['name_identifiers'][0]['legal_person_name'] = args.name
+    template['id'] = args.id
+    template['trisa_endpoint'] = args.endpoint
 
-    # Write the fixture to the output path
-    with open(output_path, 'w') as output_file:
+    # Parse the pem certificate into a base64 string
+    certs = pem.parse_file(args.cert)
+    encoded = base64.b64encode(certs[0].as_bytes())
+    template['signing_certificates'] = [{'data': encoded.decode('ascii')}]
+
+    # Write the GDS fixture to the output path
+    with open(args.output, 'w') as output_file:
         json.dump(template, output_file, indent=4)
 
 def main():
@@ -21,12 +28,12 @@ def main():
     parser.add_argument('-t', '--template', help='Path to template JSON to base fixture on', required=True)
     parser.add_argument('-o', '--output', help='Output path for the GDS VASP fixture', required=True)
     parser.add_argument('-n', '--name', help='Common name of the VASP', required=True)
-    parser.add_argument('-p', '--person', help='Legal person name of the VASP', required=True)
     parser.add_argument('-i', '--id', help='ID for the VASP', required=True)
+    parser.add_argument('-c', '--cert', help='Path to the public certificate to store in the VASP', required=True)
     parser.add_argument('-e', '--endpoint', help='TRISA endpoint for the VASP', required=True)
 
     args = parser.parse_args()
-    generate_fixtures(args.template, args.output, args.name, args.person, args.id, args.endpoint)
+    generate_fixtures(args)
 
     print('GDS VASP fixture generated at {}'.format(args.output))
 

--- a/scripts/fixtures/rvasp-fixtures.py
+++ b/scripts/fixtures/rvasp-fixtures.py
@@ -1,0 +1,42 @@
+import os
+import json
+import shutil
+import argparse
+
+VASPS_FILE = 'vasps.json'
+WALLETS_FILE = 'wallets.json'
+
+def migrate_fixtures(args):
+    # Load the VASPs fixtures
+    with open(os.path.join(args.fixtures, VASPS_FILE), 'r') as rvasp_file:
+        rvasps = json.load(rvasp_file)
+
+    names = args.names.split(',')
+
+    # Insert the rVASP name into the fixture
+    for record in rvasps:
+        for n in names:
+            if n in record['common_name']:
+                record['common_name'] = n
+                break
+
+    # Write the rVASP fixtures to the output path
+    with open(os.path.join(args.output, VASPS_FILE), 'w') as output_file:
+        json.dump(rvasps, output_file, indent=4)
+
+    # Copy the wallets fixtures to the output path
+    shutil.copy(os.path.join(args.fixtures, WALLETS_FILE), os.path.join(args.output, WALLETS_FILE))
+
+def main():
+    parser = argparse.ArgumentParser(description='rVASP Fixture Migrator')
+    parser.add_argument('-f', '--fixtures', help='Path to the rVASP fixtures', required=True)
+    parser.add_argument('-o', '--output', help='Path to the output directory for the fixtures', required=True)
+    parser.add_argument('-n', '--names', help='Comma-separated list of VASP names', required=True)
+
+    args = parser.parse_args()
+    migrate_fixtures(args)
+
+    print('rVASP fixtures migrated to {}'.format(args.output))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate-fixtures.sh
+++ b/scripts/generate-fixtures.sh
@@ -21,8 +21,8 @@ GDS_DSN="leveldb:///fixtures/db"
 COUNTRY_CODE="US"
 
 # Install required binaries: certs, gdsutil
-#go install github.com/trisacrypto/directory/cmd/certs@latest
-#go install github.com/trisacrypto/directory/cmd/gdsutil@latest
+go install github.com/trisacrypto/directory/cmd/certs@latest
+go install github.com/trisacrypto/directory/cmd/gdsutil@latest
 
 # Recreate the fixtures directory
 if [ -e fixtures ]; then

--- a/scripts/generate-fixtures.sh
+++ b/scripts/generate-fixtures.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# rVASP common names
-ALICE_NAME="api.alice.vaspbot.net"
-BOB_NAME="api.bob.vaspbot.net"
-EVIL_NAME="api.evil.vaspbot.net"
-CHARLIE_NAME="api.charlie.vaspbot.net"
-
 # rVASP UUIDs in GDS
 VASP_PREFIX="vasps::"
 ALICE_ID="alice0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0"
@@ -13,11 +7,11 @@ BOB_ID="bob0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0"
 EVIL_ID="evile0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0"
 CHARLIE_ID="charlie0-c0c0-c0c0-c0c0-c0c0c0c0c0c0"
 
-# rVASP endpoints
-ALICE_ENDPOINT="alice"
-BOB_ENDPOINT="bob"
-EVIL_ENDPOINT="evil"
-CHARLIE_ENDPOINT="charlie"
+# rVASP common names - these should match the service names in docker compose
+ALICE_NAME="alice"
+BOB_NAME="bob"
+EVIL_NAME="evil"
+CHARLIE_NAME="charlie"
 TRISA_PORT="4435"
 
 # GDS database DSN
@@ -27,8 +21,8 @@ GDS_DSN="leveldb:///fixtures/db"
 COUNTRY_CODE="US"
 
 # Install required binaries: certs, gdsutil
-go install github.com/trisacrypto/directory/cmd/certs@latest
-go install github.com/trisacrypto/directory/cmd/gdsutil@latest
+#go install github.com/trisacrypto/directory/cmd/certs@latest
+#go install github.com/trisacrypto/directory/cmd/gdsutil@latest
 
 # Recreate the fixtures directory
 if [ -e fixtures ]; then
@@ -41,28 +35,32 @@ mkdir -p fixtures/certs
 
 certs init -c fixtures/certs/ca.gz
 mkdir -p fixtures/certs/alice
-certs issue -c fixtures/certs/ca.gz -o fixtures/certs/alice/cert.pem -n $ALICE_ENDPOINT -O localhost -C $COUNTRY_CODE
+certs issue -c fixtures/certs/ca.gz -o fixtures/certs/alice/cert.pem -n $ALICE_NAME -O localhost -C $COUNTRY_CODE
 mkdir -p fixtures/certs/bob
-certs issue -c fixtures/certs/ca.gz -o fixtures/certs/bob/cert.pem -n $BOB_ENDPOINT -O localhost -C $COUNTRY_CODE
+certs issue -c fixtures/certs/ca.gz -o fixtures/certs/bob/cert.pem -n $BOB_NAME -O localhost -C $COUNTRY_CODE
 mkdir -p fixtures/certs/charlie
-certs issue -c fixtures/certs/ca.gz -o fixtures/certs/charlie/cert.pem -n $CHARLIE_ENDPOINT -O localhost -C $COUNTRY_CODE
+certs issue -c fixtures/certs/ca.gz -o fixtures/certs/charlie/cert.pem -n $CHARLIE_NAME -O localhost -C $COUNTRY_CODE
 
 certs init -c fixtures/certs/ca.evil.gz
 mkdir -p fixtures/certs/evil
-certs issue -c fixtures/certs/ca.evil.gz -o fixtures/certs/evil/cert.pem -n $EVIL_ENDPOINT -O localhost -C $COUNTRY_CODE
+certs issue -c fixtures/certs/ca.evil.gz -o fixtures/certs/evil/cert.pem -n $EVIL_NAME -O localhost -C $COUNTRY_CODE
 
-# Generate the rVASP fixtures from the template
-mkdir -p fixtures/vasps
-python scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/vasps/alice.json -n $ALICE_NAME -p $ALICE_ENDPOINT -i $ALICE_ID -e $ALICE_ENDPOINT:$TRISA_PORT
-python scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/vasps/bob.json -n $BOB_NAME -p $BOB_ENDPOINT -i $BOB_ID -e $BOB_ENDPOINT:$TRISA_PORT
-python scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/vasps/evil.json -n $EVIL_NAME -p $EVIL_ENDPOINT -i $EVIL_ID -e $EVIL_ENDPOINT:$TRISA_PORT
-python scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/vasps/charlie.json -n $CHARLIE_NAME -p $CHARLIE_ENDPOINT -i $CHARLIE_ID -e $CHARLIE_ENDPOINT:$TRISA_PORT
+# Generate the GDS fixtures from the template
+mkdir -p fixtures/gds
+python3 scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/gds/alice.json -n $ALICE_NAME -i $ALICE_ID -c fixtures/certs/alice/cert.pem -e $ALICE_NAME:$TRISA_PORT
+python3 scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/gds/bob.json -n $BOB_NAME -i $BOB_ID -c fixtures/certs/bob/cert.pem -e $BOB_NAME:$TRISA_PORT
+python3 scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/gds/evil.json -n $EVIL_NAME -i $EVIL_ID -c fixtures/certs/evil/cert.pem -e $EVIL_NAME:$TRISA_PORT
+python3 scripts/fixtures/gds-fixture.py -t scripts/fixtures/template.json -o fixtures/gds/charlie.json -n $CHARLIE_NAME -i $CHARLIE_ID -c fixtures/certs/charlie/cert.pem -e $CHARLIE_NAME:$TRISA_PORT
 
-# Store the fixtures in the GDS database
-gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$ALICE_ID fixtures/vasps/alice.json
-gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$BOB_ID fixtures/vasps/bob.json
-gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$EVIL_ID fixtures/vasps/evil.json
-gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$CHARLIE_ID fixtures/vasps/charlie.json
+# Migrate the rVASP fixtures to the fixtures directory
+mkdir -p fixtures/rvasps
+python3 scripts/fixtures/rvasp-fixtures.py -f pkg/rvasp/fixtures -o fixtures/rvasps -n $ALICE_NAME,$BOB_NAME,$EVIL_NAME,$CHARLIE_NAME
+
+# Store the rVASP records in the GDS database
+gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$ALICE_ID fixtures/gds/alice.json
+gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$BOB_ID fixtures/gds/bob.json
+gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$EVIL_ID fixtures/gds/evil.json
+gdsutil ldb:put -d $GDS_DSN $VASP_PREFIX$CHARLIE_ID fixtures/gds/charlie.json
 
 # Confirm the keys in the database
 echo ""


### PR DESCRIPTION
This PR fixes SC-7143 and SC-7144. The rVASPs now check for existence of the endpoint on the peer before trying to do key exchanges or transfers, and use the peers cache instead of always performing the GDS lookups. This also cleans up a lot of the error handling by returning errors in the envelope instead of in the gRPC error.