### PR TITLE
SC-7278 fix identity validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.7.1
 	github.com/trisacrypto/directory v1.3.1
-	github.com/trisacrypto/trisa v0.3.5
+	github.com/trisacrypto/trisa v0.3.6
 	github.com/urfave/cli v1.22.5
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/trisacrypto/trisa v0.3.4 h1:4GF5cpHY9Pg3Qupbp+mzIUMRwbxUFNXed82V7UB0u
 github.com/trisacrypto/trisa v0.3.4/go.mod h1:5VC6uJBIyiPreZfR67Mri6+CVXIuVuFZwTPromBPi9g=
 github.com/trisacrypto/trisa v0.3.5 h1:aRn6vSJ/LFc6e0lFy1vxdZfQHIak9VQpu9Ny//q99aE=
 github.com/trisacrypto/trisa v0.3.5/go.mod h1:5VC6uJBIyiPreZfR67Mri6+CVXIuVuFZwTPromBPi9g=
+github.com/trisacrypto/trisa v0.3.6 h1:AaD4O/0gNLUbdf3A6zP420Jq19JWtt/31WicR9oj+Xc=
+github.com/trisacrypto/trisa v0.3.6/go.mod h1:5VC6uJBIyiPreZfR67Mri6+CVXIuVuFZwTPromBPi9g=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
This fixes the identity payload validation so that the beneficiary fields are only checked on the "repair" policies, and also fixes the problem where a nil response was being returned to gRPC.