### PR TITLE
SC-7425 Improve beneficiary identity check

### DIFF
--- a/pkg/rvasp/db/fixtures_test.go
+++ b/pkg/rvasp/db/fixtures_test.go
@@ -13,6 +13,11 @@ func TestLoadVASPs(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 4, len(vasps))
+	for _, vasp := range vasps {
+		identity, err := vasp.LoadIdentity()
+		require.NoError(t, err, "failed to load identity for vasp fixture %s", vasp.Name)
+		require.NoError(t, identity.GetLegalPerson().Validate(), "identity for vasp fixture %s must be a valid ivms101.LegalPerson", vasp.Name)
+	}
 }
 
 func TestLoadWallets(t *testing.T) {
@@ -21,4 +26,10 @@ func TestLoadWallets(t *testing.T) {
 
 	require.Equal(t, 16, len(wallets))
 	require.Equal(t, 16, len(accounts))
+	for _, account := range accounts {
+		identity, err := account.LoadIdentity()
+		require.NoError(t, err, "failed to load identity for account fixture %s", account.Name)
+		require.NoError(t, identity.GetNaturalPerson().Validate(), "identity for account fixture %s must be a valid ivms101.NaturalPerson", account.Name)
+		require.NotEmpty(t, account.WalletAddress, "account fixture %s must have a wallet address", account.Name)
+	}
 }

--- a/pkg/rvasp/rvasp.go
+++ b/pkg/rvasp/rvasp.go
@@ -227,9 +227,7 @@ func (s *Server) Transfer(ctx context.Context, req *pb.TransferRequest) (reply *
 	}
 
 	// Build the transfer response
-	reply = &pb.TransferReply{
-		Transaction: xfer.Proto(),
-	}
+	reply = &pb.TransferReply{}
 
 	// Handle rVASP errors and TRISA protocol errors
 	if transferError != nil {
@@ -247,6 +245,9 @@ func (s *Server) Transfer(ctx context.Context, req *pb.TransferRequest) (reply *
 			xfer.SetState(pb.TransactionState_FAILED)
 		}
 	}
+
+	// Populate the transfer response with the transaction details
+	reply.Transaction = xfer.Proto()
 
 	// Save the updated transaction
 	// TODO: Clean up completed transactions in the database

--- a/pkg/rvasp/trisa.go
+++ b/pkg/rvasp/trisa.go
@@ -420,7 +420,8 @@ func (s *TRISA) handleTransaction(ctx context.Context, peer *peers.Peer, in *pro
 		return nil, protocol.Errorf(protocol.InternalError, "unknown policy '%s' for wallet '%s'", policy, account.WalletAddress)
 	}
 
-	if transferError != nil {
+	// Mark transaction as failed if it was not rejected but an error occurred
+	if xfer.State != pb.TransactionState_REJECTED && transferError != nil {
 		log.Debug().Err(transferError).Msg("transfer failed")
 		xfer.SetState(pb.TransactionState_FAILED)
 	}


### PR DESCRIPTION
This fixes an rVASP -> rVASP issue concerning the `SyncRequire` policy.

On the originator side, the rVASP generates an identity payload with a non-nil (but empty) beneficiary identity. However, on the beneficiary side the rVASP validates that the beneficiary identity is non-nil. This was causing an issue on `SendPartial` -> `SyncRequire` because the originating rVASP is generating an empty payload but the beneficiary rVASP assumes this is valid.

To fix this, the validation check is improved to validate the actual fields within the beneficiary identity on the identity payload. The validation now uses the TRISA ivms methods to verify the `LegalPerson` (the beneficiary VASP) and `NaturalPerson` (the beneficiary account).