### PR TITLE
Transfer Endpoints

### DIFF
--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -136,6 +136,10 @@ func main() {
 					Usage: "callback for the beneficiary to reply to",
 					Value: "foo",
 				},
+				cli.BoolFlag{
+					Name:  "r, reject",
+					Usage: "whether or not the transfer will be rejected",
+				},
 			},
 		},
 		{
@@ -230,7 +234,10 @@ func serve(c *cli.Context) (err error) {
 // sends a POST request to the register endpoint
 func register(c *cli.Context) (err error) {
 	url := fmt.Sprintf("http://%s/register", c.String("address"))
-	body := fmt.Sprintf(`{"name": "%s", "assettype": %d, "walletaddress": "%s"}`, c.String("name"), c.Int("assettype"), c.String("walletaddress"))
+	body := fmt.Sprintf(`{"name": "%s", "assettype": %d, "walletaddress": "%s"}`,
+		c.String("name"),
+		c.Int("assettype"),
+		c.String("walletaddress"))
 	var response string
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
@@ -253,7 +260,9 @@ func listUsers(c *cli.Context) (err error) {
 // sends a GET request to the gettraveladdress endpoint
 func getTravelAddress(c *cli.Context) (err error) {
 	var response string
-	url := fmt.Sprintf("http://%s/gettraveladdress/%s", c.String("address"), c.String("id"))
+	url := fmt.Sprintf("http://%s/gettraveladdress/%s",
+		c.String("address"),
+		c.String("id"))
 	if response, err = getRequest(url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -282,7 +291,11 @@ func transfer(c *cli.Context) (err error) {
 	}
 
 	var response string
-	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": %d, "amount": %f, "callback": "%s"}`, ivms101, c.Int("assettype"), c.Float64("amount"), c.String("callback"))
+	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": %d, "amount": %f, "callback": "%s", "reject": "%t"}`,
+		ivms101, c.Int("assettype"),
+		c.Float64("amount"),
+		c.String("callback"),
+		c.Bool("reject"))
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -293,7 +306,9 @@ func transfer(c *cli.Context) (err error) {
 // sends a GET request to the transfer endpoint
 func getTransfer(c *cli.Context) (err error) {
 	var response string
-	url := fmt.Sprintf("http://%s/gettransfer/%s", c.String("address"), c.String("id"))
+	url := fmt.Sprintf("http://%s/gettransfer/%s",
+		c.String("address"),
+		c.String("id"))
 	if response, err = getRequest(url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -305,13 +320,17 @@ func getTransfer(c *cli.Context) (err error) {
 func resolve(c *cli.Context) (err error) {
 	var body string
 	if c.Bool("approve") {
-		body = fmt.Sprintf(`{"approved": {"address": "%s", "callback: "%s"}`, c.String("address"), c.String("callback"))
+		body = fmt.Sprintf(`{"approved": {"address": "%s", "callback: "%s"}`,
+			c.String("address"),
+			c.String("callback"))
 	} else {
 		body = fmt.Sprintln(`{"rejected": "transfer rejected"}`)
 	}
 
 	var response string
-	url := fmt.Sprintf("http://%s/inquiryresolution/%s", c.String("address"), c.String("id"))
+	url := fmt.Sprintf("http://%s/inquiryresolution/%s",
+		c.String("address"),
+		c.String("id"))
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -329,7 +348,9 @@ func confirm(c *cli.Context) (err error) {
 	}
 
 	var response string
-	url := fmt.Sprintf("http://%s/transferconfirmation/%s", c.String("address"), c.String("id"))
+	url := fmt.Sprintf("http://%s/transferconfirmation/%s",
+		c.String("address"),
+		c.String("id"))
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fiatjaf/go-lnurl"
 	"github.com/joho/godotenv"
 	"github.com/trisacrypto/testnet/pkg"
 	openvasp "github.com/trisacrypto/testnet/pkg/openvasp/web-service-gin"
@@ -80,7 +81,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "l, lnurl",
 					Usage: "lnurl encoding the address of the gin server",
-					Value: "localhost:4435",
+					Value: "LNURL1DP68GUP69UHKCMMRV9KXSMMNWSARGDPNX5HHGUNPDEEKVETJ9UUNYDNRVYMRJCFDXE3NYV3DXSEX2D3D8YCNQDFDXYCKZC34V3JNZV3NXA3R7ARPVU7HGUNPWEJKC5N4D3J5JMN3W45HY7GQ9NV7V",
 				},
 				cli.StringFlag{
 					Name:  "p, path",
@@ -95,7 +96,7 @@ func main() {
 				cli.Float64Flag{
 					Name:  "c, amount",
 					Usage: "amount of the asset type to be transfered",
-					Value: 1,
+					Value: 100,
 				},
 			},
 		},
@@ -189,12 +190,16 @@ func transfer(c *cli.Context) (err error) {
 	if jsonbytes, err = ioutil.ReadAll(file); err != nil {
 		return cli.NewExitError(err, 1)
 	}
+	ivms101 := strings.ReplaceAll(string(jsonbytes), `"`, `*`)
+	ivms101 = strings.ReplaceAll(ivms101, "\n", "+")
+
+	var url string
+	if url, err = lnurl.LNURLDecode(c.String("lnurl")); err != nil {
+		return cli.NewExitError(err, 1)
+	}
 
 	var response string
-	url := fmt.Sprintf("http://%s/transfer", c.String("lnurl"))
-	escaped := strings.ReplaceAll(fmt.Sprintf(`%s`, jsonbytes), `"`, `*`)
-	escaped = strings.ReplaceAll(escaped, "\n", "+")
-	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": 3, "amount": 3, "callback": "foo"}`, escaped)
+	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": 3, "amount": 3, "callback": "foo"}`, ivms101)
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -99,9 +99,9 @@ func main() {
 					Value: "localhost:4435",
 				},
 				cli.StringFlag{
-					Name:  "i, id",
-					Usage: "The customer id of the registered user to lookup",
-					Value: "b02245ba-de1e-44ed-b51b-2e93dbca426d",
+					Name:     "i, id",
+					Usage:    "The customer id of the registered user to lookup",
+					Required: true,
 				},
 			},
 		},
@@ -154,9 +154,9 @@ func main() {
 					Value: "localhost:4435",
 				},
 				cli.StringFlag{
-					Name:  "i, id",
-					Usage: "transfer id of the transfer to lookup",
-					Value: "a6f1c411-5cc0-4867-b0eb-5f4806c70803",
+					Name:     "i, id",
+					Usage:    "transfer id of the transfer to lookup",
+					Required: true,
 				},
 			},
 		},
@@ -181,7 +181,7 @@ func main() {
 					Usage: "whether or not the transfer should be rejected",
 				},
 				cli.StringFlag{
-					Name:  "a, address",
+					Name:  "t, assetaddress",
 					Usage: "amount of the asset type to be transfered",
 					Value: "some payment address",
 				},
@@ -323,7 +323,7 @@ func resolve(c *cli.Context) (err error) {
 	var body string
 	if c.Bool("approve") {
 		body = fmt.Sprintf(`{"approved": {"address": "%s", "callback: "%s"}`,
-			c.String("address"),
+			c.String("assetaddress"),
 			c.String("callback"))
 	} else {
 		body = fmt.Sprintln(`{"rejected": "transfer rejected"}`)

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -279,7 +279,7 @@ func transfer(c *cli.Context) (err error) {
 	defer file.Close()
 
 	var jsonbytes []byte
-	if jsonbytes, err = ioutil.ReadAll(file); err != nil {
+	if err = json.NewDecoder(file).Decode(&jsonbytes); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	//TODO: Find a better way to avoid binding issues with quotes
@@ -375,7 +375,7 @@ func postRequest(body string, url string) (_ string, err error) {
 	}
 
 	var responseBody []byte
-	if responseBody, err = ioutil.ReadAll(response.Body); err != nil {
+	if err = json.NewDecoder(response.Body).Decode(&responseBody); err != nil {
 		return "", cli.NewExitError(err, 1)
 	}
 	return string(responseBody), nil
@@ -395,7 +395,7 @@ func getRequest(url string) (_ string, err error) {
 	}
 
 	var responseBody []byte
-	if responseBody, err = ioutil.ReadAll(response.Body); err != nil {
+	if err = json.NewDecoder(response.Body).Decode(&responseBody); err != nil {
 		return "", cli.NewExitError(err, 1)
 	}
 	return string(responseBody), nil

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -150,8 +150,8 @@ func transfer(c *cli.Context) (err error) {
 	}
 
 	payload := &openvasp.Payload{
-		IVMS101:  ivms101,
-		Asset:    c.String("asset"),
+		IVMS101: ivms101,
+		//Asset:    c.String("asset"),
 		Amount:   c.Float64("amount"),
 		Callback: "foo",
 	}

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -111,6 +111,11 @@ func main() {
 					Usage: "address of the gin server",
 					Value: "localhost:4435",
 				},
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "address of the gin server",
+					Value: "foo",
+				},
 				cli.BoolFlag{
 					Name:  "y, approve",
 					Usage: "asset type for transfer, i.e. Bitcoin, Etheriem, etc.",
@@ -124,6 +129,28 @@ func main() {
 					Name:  "c, callback",
 					Usage: "amount of the asset type to be transfered",
 					Value: "foo",
+				},
+			},
+		},
+		{
+			Name:     "confirm",
+			Usage:    "",
+			Category: "client",
+			Action:   confirm,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "a, address",
+					Usage: "address of the gin server",
+					Value: "localhost:4435",
+				},
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "address of the gin server",
+					Value: "foo",
+				},
+				cli.BoolFlag{
+					Name:  "c, cancelled",
+					Usage: "amount of the asset type to be transfered",
 				},
 			},
 		},
@@ -191,9 +218,27 @@ func resolve(c *cli.Context) (err error) {
 	} else {
 		body = fmt.Sprintln(`{"rejected": "transfer rejected"}`)
 	}
-	url := fmt.Sprintf("http://%s/inquiryResolution", c.String("address"))
 
 	var response string
+	url := fmt.Sprintf("http://%s/inquiryresolution/%s", c.String("address"), c.String("id"))
+	if response, err = postRequest(body, url); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Println(response)
+	return nil
+}
+
+//
+func confirm(c *cli.Context) (err error) {
+	var body string
+	if !c.Bool("cancelled") {
+		body = fmt.Sprintln(`{"txid": "some asset-specific tx identifier"`)
+	} else {
+		body = fmt.Sprintln(`{"canceled": "transfer canceled"}`)
+	}
+
+	var response string
+	url := fmt.Sprintf("http://%s/transferconfirmation/%s", c.String("address"), c.String("id"))
 	if response, err = postRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -222,7 +221,7 @@ func register(c *cli.Context) (err error) {
 	url := fmt.Sprintf("http://%s/register", c.String("address"))
 	body := `{"name": "Mildred Tilcott", "assettype": 3, "walletaddress": "926ca69a-6c22-42e6-9105-11ab5de1237b"}`
 	var response string
-	if response, err = postRequest(body, url); err != nil {
+	if response, err = openvasp.PostRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	fmt.Println(response)
@@ -273,7 +272,7 @@ func transfer(c *cli.Context) (err error) {
 
 	var response string
 	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": 3, "amount": 3, "callback": "foo"}`, ivms101)
-	if response, err = postRequest(body, url); err != nil {
+	if response, err = openvasp.PostRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	fmt.Println(response)
@@ -302,7 +301,7 @@ func resolve(c *cli.Context) (err error) {
 
 	var response string
 	url := fmt.Sprintf("http://%s/inquiryresolution/%s", c.String("address"), c.String("id"))
-	if response, err = postRequest(body, url); err != nil {
+	if response, err = openvasp.PostRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	fmt.Println(response)
@@ -320,32 +319,11 @@ func confirm(c *cli.Context) (err error) {
 
 	var response string
 	url := fmt.Sprintf("http://%s/transferconfirmation/%s", c.String("address"), c.String("id"))
-	if response, err = postRequest(body, url); err != nil {
+	if response, err = openvasp.PostRequest(body, url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	fmt.Println(response)
 	return nil
-}
-
-//
-func postRequest(body string, url string) (_ string, err error) {
-	var request *http.Request
-	byteBody := []byte(body)
-	if request, err = http.NewRequest(http.MethodPost, url, bytes.NewReader(byteBody)); err != nil {
-		return "", err
-	}
-	request.Header.Set("Content-Type", "application/json")
-
-	var response *http.Response
-	if response, err = http.DefaultClient.Do(request); err != nil {
-		return "", cli.NewExitError(err, 1)
-	}
-
-	var responseBody []byte
-	if responseBody, err = ioutil.ReadAll(response.Body); err != nil {
-		return "", cli.NewExitError(err, 1)
-	}
-	return string(responseBody), nil
 }
 
 //

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -282,6 +282,7 @@ func transfer(c *cli.Context) (err error) {
 	if jsonbytes, err = ioutil.ReadAll(file); err != nil {
 		return cli.NewExitError(err, 1)
 	}
+	//TODO: Find a better way to avoid binding issues with quotes
 	ivms101 := strings.ReplaceAll(string(jsonbytes), `"`, `*`)
 	ivms101 = strings.ReplaceAll(ivms101, "\n", "+")
 

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -160,12 +160,13 @@ func transfer(c *cli.Context) (err error) {
 
 	var request *http.Request
 	requestURL := fmt.Sprintf("http://%s/transfer", c.String("address"))
-	body := []byte(`{"client_message": "hello world"}`)
+	newBody := fmt.Sprintf(`{"ivms101": "%s", "assettype": 3, "amount": 3, "callback": "foo"}`, ivms101)
+	fmt.Println(newBody)
+	body := []byte(newBody)
 	if request, err = http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(body)); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("data", fmt.Sprintf(`{"ivms101": %s, "assettype": 3, "amount": "926ca69a-6c22-42e6-9105-11ab5de1237b", "callback": "foo"}`, ivms101.String()))
 
 	var response *http.Response
 	client := &http.Client{}

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -62,13 +62,44 @@ func main() {
 				},
 				cli.IntFlag{
 					Name:  "t, assetType",
-					Usage: "name of the OpenVASP customer",
+					Usage: "AssetType (for example bitcoin) of the OpenVASP customer",
 					Value: 3,
 				},
 				cli.StringFlag{
 					Name:  "w, walletAddress",
-					Usage: "name of the OpenVASP customer",
+					Usage: "WalletAddress of the OpenVASP customer",
 					Value: "926ca69a-6c22-42e6-9105-11ab5de1237b",
+				},
+			},
+		},
+		{
+			Name:     "listusers",
+			Usage:    "",
+			Category: "client",
+			Action:   listUsers,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "a, address",
+					Usage: "address of the gin server",
+					Value: "localhost:4435",
+				},
+			},
+		},
+		{
+			Name:     "gettraveladdress",
+			Usage:    "",
+			Category: "client",
+			Action:   getTravelAddress,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "a, address",
+					Usage: "address of the gin server",
+					Value: "localhost:4435",
+				},
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "address of the gin server",
+					Value: "b02245ba-de1e-44ed-b51b-2e93dbca426d",
 				},
 			},
 		},
@@ -179,6 +210,28 @@ func register(c *cli.Context) (err error) {
 }
 
 //
+func listUsers(c *cli.Context) (err error) {
+	var response string
+	url := fmt.Sprintf("http://%s/listusers", c.String("address"))
+	if response, err = getRequest(url); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Println(response)
+	return nil
+}
+
+//
+func getTravelAddress(c *cli.Context) (err error) {
+	var response string
+	url := fmt.Sprintf("http://%s/listusers/%s", c.String("address"), c.String("id"))
+	if response, err = getRequest(url); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Println(response)
+	return nil
+}
+
+//
 func transfer(c *cli.Context) (err error) {
 	var file *os.File
 	if file, err = os.Open(c.String("path")); err != nil {
@@ -253,8 +306,26 @@ func postRequest(body string, url string) (_ string, err error) {
 	request.Header.Set("Content-Type", "application/json")
 
 	var response *http.Response
-	client := &http.Client{}
-	if response, err = client.Do(request); err != nil {
+	if response, err = http.DefaultClient.Do(request); err != nil {
+		return "", cli.NewExitError(err, 1)
+	}
+
+	var responseBody []byte
+	if responseBody, err = ioutil.ReadAll(response.Body); err != nil {
+		return "", cli.NewExitError(err, 1)
+	}
+	return string(responseBody), nil
+}
+
+//
+func getRequest(url string) (_ string, err error) {
+	var request *http.Request
+	if request, err = http.NewRequest(http.MethodGet, url, nil); err != nil {
+		return "", err
+	}
+
+	var response *http.Response
+	if response, err = http.DefaultClient.Do(request); err != nil {
 		return "", cli.NewExitError(err, 1)
 	}
 

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -33,14 +33,16 @@ func main() {
 			Action:   serve,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "a, address",
-					Usage: "the address and port to bind the server on",
-					Value: "localhost:4435",
+					Name:   "a, address",
+					Usage:  "the address and port to bind the server on",
+					Value:  "localhost:4435",
+					EnvVar: "OPENVASP_BIND_ADDR",
 				},
 				cli.StringFlag{
-					Name:  "d, db",
-					Usage: "the dsn of the postgres database to connect to",
-					Value: "localhost:4434",
+					Name:   "d, db",
+					Usage:  "the dsn of the postgres database to connect to",
+					Value:  "localhost:4434",
+					EnvVar: "OPENVASP_DATABASE_DSN",
 				},
 			},
 		},
@@ -128,6 +130,24 @@ func main() {
 					Name:  "c, amount",
 					Usage: "amount of the asset type to be transfered",
 					Value: 100,
+				},
+			},
+		},
+		{
+			Name:     "gettransfer",
+			Usage:    "",
+			Category: "client",
+			Action:   getTransfer,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "a, address",
+					Usage: "address of the gin server",
+					Value: "localhost:4435",
+				},
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "transfer id of the transfer to lookup",
+					Value: "a6f1c411-5cc0-4867-b0eb-5f4806c70803",
 				},
 			},
 		},
@@ -223,7 +243,7 @@ func listUsers(c *cli.Context) (err error) {
 //
 func getTravelAddress(c *cli.Context) (err error) {
 	var response string
-	url := fmt.Sprintf("http://%s/listusers/%s", c.String("address"), c.String("id"))
+	url := fmt.Sprintf("http://%s/gettraveladdress/%s", c.String("address"), c.String("id"))
 	if response, err = getRequest(url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -254,6 +274,17 @@ func transfer(c *cli.Context) (err error) {
 	var response string
 	body := fmt.Sprintf(`{"ivms101": "%s", "assettype": 3, "amount": 3, "callback": "foo"}`, ivms101)
 	if response, err = postRequest(body, url); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Println(response)
+	return nil
+}
+
+//
+func getTransfer(c *cli.Context) (err error) {
+	var response string
+	url := fmt.Sprintf("http://%s/gettransfer/%s", c.String("address"), c.String("id"))
+	if response, err = getRequest(url); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	fmt.Println(response)

--- a/cmd/openvasp/main.go
+++ b/cmd/openvasp/main.go
@@ -232,7 +232,7 @@ func resolve(c *cli.Context) (err error) {
 func confirm(c *cli.Context) (err error) {
 	var body string
 	if !c.Bool("cancelled") {
-		body = fmt.Sprintln(`{"txid": "some asset-specific tx identifier"`)
+		body = fmt.Sprintln(`{"txid": "some asset-specific tx identifier"}`)
 	} else {
 		body = fmt.Sprintln(`{"canceled": "transfer canceled"}`)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/fiatjaf/go-lnurl v1.3.1
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
@@ -14,7 +15,6 @@ require (
 	github.com/trisacrypto/directory v1.3.1
 	github.com/trisacrypto/trisa v0.3.6
 	github.com/urfave/cli v1.22.5
-	github.com/xplorfin/lnurlauth v0.60.0
 	google.golang.org/grpc v1.56.0
 	google.golang.org/protobuf v1.30.0
 	gorm.io/driver/postgres v1.5.2
@@ -27,7 +27,6 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fiatjaf/go-lnurl v1.3.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -51,7 +50,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/tidwall/gjson v1.9.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -606,14 +606,11 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EDDYCJY/fake-useragent v0.2.0/go.mod h1:5wn3zzlDxhKW6NYknushqinPcAqZcAPHy8lLczCdJdc=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
-github.com/PuerkitoBio/goquery v1.6.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -630,9 +627,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
@@ -654,7 +649,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/brianvoe/gofakeit/v5 v5.11.2/go.mod h1:/ZENnKqX+XrN8SORLe/fu5lZDIo1tuPncWuRD+eyhSI=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta h1:At9hIZdJW0s9E/fAz28nrz6AmcNlSVucCH796ZteX1M=
 github.com/btcsuite/btcd v0.21.0-beta/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MRgMY/8NJ7K94=
@@ -726,7 +720,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -766,7 +759,6 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
-github.com/fasthttp/router v1.4.0/go.mod h1:uTM3xaLINfEk/uqId8rv8tzwr47+HZuxopzUWfwD4qg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fiatjaf/go-lnurl v1.3.1 h1:9Qn4n1ZyzTMW/YuVX2Wr9cE+LEAzpE1hrCbxVK/yBKE=
@@ -802,7 +794,6 @@ github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmn
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a/go.mod h1:I79BieaU4fxrw4LMXby6q5OS9XnoR9UIKLOzDFjUmuw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
@@ -1006,7 +997,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc/go.mod h1:UlaC6ndby46IJz9m/03cZPKKkR9ykeIVBBDE3UDBdJk=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=
@@ -1018,7 +1008,6 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZ
 github.com/jackc/pgx/v5 v5.3.1 h1:Fcr8QJ1ZeLi5zsPZqQeUZhNhxfkkKBOgJuYkJHoBOtU=
 github.com/jackc/pgx/v5 v5.3.1/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
-github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -1067,7 +1056,6 @@ github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
@@ -1097,7 +1085,6 @@ github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/localtunnel/go-localtunnel v0.0.0-20170326223115-8a804488f275/go.mod h1:zt6UU74K6Z6oMOYJbJzYpYucqdcQwSMPBEdSvGiaUMw=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
@@ -1105,7 +1092,6 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -1123,7 +1109,6 @@ github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mileusna/useragent v1.0.2/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -1164,12 +1149,10 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
-github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
@@ -1187,7 +1170,6 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
-github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -1195,7 +1177,6 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pkg/browser v0.0.0-20210621091255-c198bc921a84/go.mod h1:yvwcBfzEX4m+eTgxPBbNYytaWFv4PSQzBaeYjxp8Iik=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1256,7 +1237,6 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZ
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/savsgio/gotils v0.0.0-20210617111740-97865ed5a873/go.mod h1:dmPawKuiAeG/aFYVs2i+Dyosoo7FNcm+Pi8iK6ZUrX8=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
@@ -1271,8 +1251,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
-github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1342,20 +1320,13 @@ github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5Lb
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
-github.com/valyala/fasthttp v1.27.0/go.mod h1:cmWIqlu99AO/RKcp1HWaViTqc57FswJOfYYdPJBl8BA=
-github.com/valyala/fasthttp v1.28.0/go.mod h1:cmWIqlu99AO/RKcp1HWaViTqc57FswJOfYYdPJBl8BA=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xplorfin/filet v0.3.0/go.mod h1:j2xe3SQktEiFiLbqy4aRrgGT9DHi1FXHNFin08BcShE=
-github.com/xplorfin/lnurlauth v0.60.0 h1:dFZw/jIPCkKjsV0k/6Uo0QkosiUMT3HakkYFv60kbP0=
-github.com/xplorfin/lnurlauth v0.60.0/go.mod h1:iUo/VEq3XJ42b/3rm3LGAig2snblq0d03nHwqVr7XNE=
-github.com/xplorfin/netutils v0.45.0/go.mod h1:laf6c+uN3F1zVpnlW/xReqoCE/RfO1EtVaAO5IY/A3w=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
@@ -1420,7 +1391,6 @@ golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
@@ -1497,7 +1467,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1539,7 +1508,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -1547,7 +1515,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -1682,7 +1649,6 @@ golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210304124612-50617c2ba197/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/openvasp/testdata/identity.json
+++ b/pkg/openvasp/testdata/identity.json
@@ -49,7 +49,7 @@
         "originating_vasp": {
             "legal_person": {
                 "name": {
-                    "name_identifier": [
+                    "name_identifiers": [
                         {
                             "legal_person_name": "VASP A",
                             "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"

--- a/pkg/openvasp/testdata/identity.json
+++ b/pkg/openvasp/testdata/identity.json
@@ -1,8 +1,6 @@
 {
-    "asset": {
-        "slip0044": "foo"
-    },
-    "amount": 1,
+    "asset": 1,
+    "amount": 1.0,
     "callback": "https://originator.com/implementation/defined/path/for/inquiryResolution",
     "IVMS101": {
         "originator": {

--- a/pkg/openvasp/testdata/identity.json
+++ b/pkg/openvasp/testdata/identity.json
@@ -1,70 +1,64 @@
 {
-    "asset": 1,
-    "amount": 1.0,
-    "callback": "https://originator.com/implementation/defined/path/for/inquiryResolution",
-    "IVMS101": {
-        "originator": {
-            "originatorPersons": [
-                {
-                    "naturalPerson": {
-                        "name": {
-                            "nameIdentifier": [
-                                {
-                                    "primaryIdentifier": "Post",
-                                    "secondaryIdentifier": "Johnny",
-                                    "nameIdentifierType": "LEGL"
-                                }
-                            ]
-                        },
-                        "geographicAddress": [
-                            {
-                                "addressType": "GEOG",
-                                "streetName": "Potential Street",
-                                "buildingNumber": "123",
-                                "buildingName": "Cheese Hut",
-                                "postCode": "91361",
-                                "townName": "Thousand Oaks",
-                                "countrySubDivision": "California",
-                                "country": "US"
-                            }
-                        ],
-                        "customerIdentification": "1002390"
-                    }
-                }
-            ]
-        },
-        "beneficiary": {
-            "beneficiaryPersons": [
-                {
-                    "naturalPerson": {
-                        "name": {
-                            "nameIdentifier": [
-                                {
-                                    "primaryIdentifier": "MachuPichu",
-                                    "secondaryIdentifier": "Freddie",
-                                    "nameIdentifierType": "LEGL"
-                                }
-                            ]
-                        }
-                    }
-                }
-            ]
-        },
-        "originatingVASP": {
-            "originatingVASP": {
-                "legalPerson": {
+    "originator": {
+        "originator_persons": [
+            {
+                "natural_person": {
                     "name": {
-                        "nameIdentifier": [
+                        "name_identifiers": [
                             {
-                                "legalPersonName": "VASP A",
-                                "legalPersonNameIdentifierType": "LEGL"
+                                "primary_identifier": "Post",
+                                "secondary_identifier": "Johnny",
+                                "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
                             }
                         ]
                     },
-                    "nationalIdentification": {
-                        "nationalIdentifier": "506700T7Z685VUOZL877",
-                        "nationalIdentifierType": "LEIX"
+                    "geographic_addresses": [
+                        {
+                            "streetName": "Potential Street",
+                            "buildingNumber": "123",
+                            "buildingName": "Cheese Hut",
+                            "postCode": "91361",
+                            "townName": "Thousand Oaks",
+                            "countrySubDivision": "California",
+                            "country": "US"
+                        }
+                    ],
+                    "customer_identification": "1002390"
+                }
+            }
+        ]
+    },
+    "beneficiary": {
+        "beneficiary_persons": [
+            {
+                "natural_person": {
+                    "name": {
+                        "name_identifiers": [
+                            {
+                                "primary_identifier": "MachuPichu",
+                                "secondary_identifier": "Freddie",
+                                "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
+                            }
+                        ]
                     }
+                }
+            }
+        ]
+    },
+    "originating_vasp": {
+        "originating_vasp": {
+            "legal_person": {
+                "name": {
+                    "name_identifier": [
+                        {
+                            "legal_person_name": "VASP A",
+                            "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+                        }
+                    ]
+                },
+                "national_identification": {
+                    "national_identifier": "506700T7Z685VUOZL877",
+                    "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX"
                 }
             }
         }

--- a/pkg/openvasp/testdata/identity.json
+++ b/pkg/openvasp/testdata/identity.json
@@ -1,229 +1,74 @@
 {
-    "identity": {
-      "@type": "type.googleapis.com/ivms101.IdentityPayload",
-      "originator": {
-        "originator_persons": [
-          {
-            "natural_person": {
-              "name": {
-                "name_identifiers": [
-                  {
-                    "primary_identifier": "Howard",
-                    "secondary_identifier": "Jane",
-                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
-                  },
-                  {
-                    "primary_identifier": "Price",
-                    "secondary_identifier": "Jane",
-                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_MAID"
-                  }
-                ],
-                "local_name_identifiers": [],
-                "phonetic_name_identifiers": []
-              },
-              "geographic_addresses": [
+    "asset": {
+        "slip0044": "foo"
+    },
+    "amount": 1,
+    "callback": "https://originator.com/implementation/defined/path/for/inquiryResolution",
+    "IVMS101": {
+        "originator": {
+            "originatorPersons": [
                 {
-                  "address_type": "ADDRESS_TYPE_CODE_HOME",
-                  "department": "",
-                  "sub_department": "",
-                  "street_name": "Greystone Street",
-                  "building_number": "28",
-                  "building_name": "",
-                  "floor": "",
-                  "post_box": "",
-                  "room": "",
-                  "post_code": "38017",
-                  "town_name": "Collierville",
-                  "town_location_name": "",
-                  "district_name": "",
-                  "country_sub_division": "TN",
-                  "address_line": [],
-                  "country": "US"
+                    "naturalPerson": {
+                        "name": {
+                            "nameIdentifier": [
+                                {
+                                    "primaryIdentifier": "Post",
+                                    "secondaryIdentifier": "Johnny",
+                                    "nameIdentifierType": "LEGL"
+                                }
+                            ]
+                        },
+                        "geographicAddress": [
+                            {
+                                "addressType": "GEOG",
+                                "streetName": "Potential Street",
+                                "buildingNumber": "123",
+                                "buildingName": "Cheese Hut",
+                                "postCode": "91361",
+                                "townName": "Thousand Oaks",
+                                "countrySubDivision": "California",
+                                "country": "US"
+                            }
+                        ],
+                        "customerIdentification": "1002390"
+                    }
                 }
-              ],
-              "national_identification": {
-                "national_identifier": "112502920",
-                "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_SOCS",
-                "country_of_issue": "US",
-                "registration_authority": "RA000748"
-              },
-              "customer_identification": "2642",
-              "date_and_place_of_birth": {
-                "date_of_birth": "1992-10-04",
-                "place_of_birth": "West Islip, NY"
-              },
-              "country_of_residence": "US"
+            ]
+        },
+        "beneficiary": {
+            "beneficiaryPersons": [
+                {
+                    "naturalPerson": {
+                        "name": {
+                            "nameIdentifier": [
+                                {
+                                    "primaryIdentifier": "MachuPichu",
+                                    "secondaryIdentifier": "Freddie",
+                                    "nameIdentifierType": "LEGL"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "originatingVASP": {
+            "originatingVASP": {
+                "legalPerson": {
+                    "name": {
+                        "nameIdentifier": [
+                            {
+                                "legalPersonName": "VASP A",
+                                "legalPersonNameIdentifierType": "LEGL"
+                            }
+                        ]
+                    },
+                    "nationalIdentification": {
+                        "nationalIdentifier": "506700T7Z685VUOZL877",
+                        "nationalIdentifierType": "LEIX"
+                    }
+                }
             }
-          }
-        ],
-        "account_numbers": [
-          "14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v"
-        ]
-      },
-      "beneficiary": {
-        "beneficiary_persons": [
-          {
-            "natural_person": {
-              "name": {
-                "name_identifiers": [
-                  {
-                    "primary_identifier": "Clark",
-                    "secondary_identifier": "Lawrence",
-                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
-                  },
-                  {
-                    "primary_identifier": "Clark",
-                    "secondary_identifier": "Larry",
-                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_ALIA"
-                  }
-                ],
-                "local_name_identifiers": [],
-                "phonetic_name_identifiers": []
-              },
-              "geographic_addresses": [
-                {
-                  "address_type": "ADDRESS_TYPE_CODE_HOME",
-                  "department": "",
-                  "sub_department": "",
-                  "street_name": "Watling St",
-                  "building_number": "249",
-                  "building_name": "",
-                  "floor": "",
-                  "post_box": "",
-                  "room": "",
-                  "post_code": "WD7 7AL",
-                  "town_name": "Radlett",
-                  "town_location_name": "",
-                  "district_name": "",
-                  "country_sub_division": "",
-                  "address_line": [],
-                  "country": "United Kingdom"
-                }
-              ],
-              "national_identification": {
-                "national_identifier": "319560446",
-                "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_DRLC",
-                "country_of_issue": "GB",
-                "registration_authority": "RA000591"
-              },
-              "customer_identification": "5610",
-              "date_and_place_of_birth": {
-                "date_of_birth": "1986-12-13",
-                "place_of_birth": "Leeds, United Kingdom"
-              },
-              "country_of_residence": "GB"
-            }
-          }
-        ],
-        "account_numbers": [
-          "14WU745djqecaJ1gmtWQGeMCFim1W5MNp3"
-        ]
-      },
-      "originating_vasp": {
-        "originating_vasp": {
-          "legal_person": {
-            "name": {
-              "name_identifiers": [
-                {
-                  "legal_person_name": "AliceCoin, Inc.",
-                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
-                },
-                {
-                  "legal_person_name": "Alice VASP",
-                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
-                },
-                {
-                  "legal_person_name": "AliceCoin",
-                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_TRAD"
-                }
-              ],
-              "local_name_identifiers": [],
-              "phonetic_name_identifiers": []
-            },
-            "geographic_addresses": [
-              {
-                "address_type": "ADDRESS_TYPE_CODE_BIZZ",
-                "department": "",
-                "sub_department": "",
-                "street_name": "Roosevelt Place",
-                "building_number": "23",
-                "building_name": "",
-                "floor": "",
-                "post_box": "",
-                "room": "",
-                "post_code": "02151",
-                "town_name": "Boston",
-                "town_location_name": "",
-                "district_name": "",
-                "country_sub_division": "MA",
-                "address_line": [],
-                "country": "US"
-              }
-            ],
-            "customer_number": "",
-            "national_identification": {
-              "national_identifier": "5493004YBI24IF4TIP92",
-              "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
-              "country_of_issue": "US",
-              "registration_authority": "RA000744"
-            },
-            "country_of_registration": "US"
-          }
         }
-      },
-      "beneficiary_vasp": {
-        "beneficiary_vasp": {
-          "legal_person": {
-            "name": {
-              "name_identifiers": [
-                {
-                  "legal_person_name": "Bob's Discount VASP, PLC",
-                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
-                },
-                {
-                  "legal_person_name": "Bob VASP",
-                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
-                }
-              ],
-              "local_name_identifiers": [],
-              "phonetic_name_identifiers": []
-            },
-            "geographic_addresses": [
-              {
-                "address_type": "ADDRESS_TYPE_CODE_BIZZ",
-                "department": "",
-                "sub_department": "",
-                "street_name": "Grimsby Road",
-                "building_number": "762",
-                "building_name": "",
-                "floor": "",
-                "post_box": "",
-                "room": "",
-                "post_code": "OX8 U89",
-                "town_name": "Oxford",
-                "town_location_name": "",
-                "district_name": "",
-                "country_sub_division": "",
-                "address_line": [],
-                "country": "GB"
-              }
-            ],
-            "customer_number": "",
-            "national_identification": {
-              "national_identifier": "213800AQUAUP6I215N33",
-              "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
-              "country_of_issue": "GB",
-              "registration_authority": "RA000589"
-            },
-            "country_of_registration": "GB"
-          }
-        }
-      },
-      "transfer_path": {
-        "transfer_path": []
-      },
-      "payload_metadata": {
-        "transliteration_method": []
-      }
     }
-  }
+}

--- a/pkg/openvasp/testdata/identity.json
+++ b/pkg/openvasp/testdata/identity.json
@@ -1,0 +1,229 @@
+{
+    "identity": {
+      "@type": "type.googleapis.com/ivms101.IdentityPayload",
+      "originator": {
+        "originator_persons": [
+          {
+            "natural_person": {
+              "name": {
+                "name_identifiers": [
+                  {
+                    "primary_identifier": "Howard",
+                    "secondary_identifier": "Jane",
+                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
+                  },
+                  {
+                    "primary_identifier": "Price",
+                    "secondary_identifier": "Jane",
+                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_MAID"
+                  }
+                ],
+                "local_name_identifiers": [],
+                "phonetic_name_identifiers": []
+              },
+              "geographic_addresses": [
+                {
+                  "address_type": "ADDRESS_TYPE_CODE_HOME",
+                  "department": "",
+                  "sub_department": "",
+                  "street_name": "Greystone Street",
+                  "building_number": "28",
+                  "building_name": "",
+                  "floor": "",
+                  "post_box": "",
+                  "room": "",
+                  "post_code": "38017",
+                  "town_name": "Collierville",
+                  "town_location_name": "",
+                  "district_name": "",
+                  "country_sub_division": "TN",
+                  "address_line": [],
+                  "country": "US"
+                }
+              ],
+              "national_identification": {
+                "national_identifier": "112502920",
+                "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_SOCS",
+                "country_of_issue": "US",
+                "registration_authority": "RA000748"
+              },
+              "customer_identification": "2642",
+              "date_and_place_of_birth": {
+                "date_of_birth": "1992-10-04",
+                "place_of_birth": "West Islip, NY"
+              },
+              "country_of_residence": "US"
+            }
+          }
+        ],
+        "account_numbers": [
+          "14HmBSwec8XrcWge9Zi1ZngNia64u3Wd2v"
+        ]
+      },
+      "beneficiary": {
+        "beneficiary_persons": [
+          {
+            "natural_person": {
+              "name": {
+                "name_identifiers": [
+                  {
+                    "primary_identifier": "Clark",
+                    "secondary_identifier": "Lawrence",
+                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_LEGL"
+                  },
+                  {
+                    "primary_identifier": "Clark",
+                    "secondary_identifier": "Larry",
+                    "name_identifier_type": "NATURAL_PERSON_NAME_TYPE_CODE_ALIA"
+                  }
+                ],
+                "local_name_identifiers": [],
+                "phonetic_name_identifiers": []
+              },
+              "geographic_addresses": [
+                {
+                  "address_type": "ADDRESS_TYPE_CODE_HOME",
+                  "department": "",
+                  "sub_department": "",
+                  "street_name": "Watling St",
+                  "building_number": "249",
+                  "building_name": "",
+                  "floor": "",
+                  "post_box": "",
+                  "room": "",
+                  "post_code": "WD7 7AL",
+                  "town_name": "Radlett",
+                  "town_location_name": "",
+                  "district_name": "",
+                  "country_sub_division": "",
+                  "address_line": [],
+                  "country": "United Kingdom"
+                }
+              ],
+              "national_identification": {
+                "national_identifier": "319560446",
+                "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_DRLC",
+                "country_of_issue": "GB",
+                "registration_authority": "RA000591"
+              },
+              "customer_identification": "5610",
+              "date_and_place_of_birth": {
+                "date_of_birth": "1986-12-13",
+                "place_of_birth": "Leeds, United Kingdom"
+              },
+              "country_of_residence": "GB"
+            }
+          }
+        ],
+        "account_numbers": [
+          "14WU745djqecaJ1gmtWQGeMCFim1W5MNp3"
+        ]
+      },
+      "originating_vasp": {
+        "originating_vasp": {
+          "legal_person": {
+            "name": {
+              "name_identifiers": [
+                {
+                  "legal_person_name": "AliceCoin, Inc.",
+                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+                },
+                {
+                  "legal_person_name": "Alice VASP",
+                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
+                },
+                {
+                  "legal_person_name": "AliceCoin",
+                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_TRAD"
+                }
+              ],
+              "local_name_identifiers": [],
+              "phonetic_name_identifiers": []
+            },
+            "geographic_addresses": [
+              {
+                "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+                "department": "",
+                "sub_department": "",
+                "street_name": "Roosevelt Place",
+                "building_number": "23",
+                "building_name": "",
+                "floor": "",
+                "post_box": "",
+                "room": "",
+                "post_code": "02151",
+                "town_name": "Boston",
+                "town_location_name": "",
+                "district_name": "",
+                "country_sub_division": "MA",
+                "address_line": [],
+                "country": "US"
+              }
+            ],
+            "customer_number": "",
+            "national_identification": {
+              "national_identifier": "5493004YBI24IF4TIP92",
+              "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+              "country_of_issue": "US",
+              "registration_authority": "RA000744"
+            },
+            "country_of_registration": "US"
+          }
+        }
+      },
+      "beneficiary_vasp": {
+        "beneficiary_vasp": {
+          "legal_person": {
+            "name": {
+              "name_identifiers": [
+                {
+                  "legal_person_name": "Bob's Discount VASP, PLC",
+                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+                },
+                {
+                  "legal_person_name": "Bob VASP",
+                  "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
+                }
+              ],
+              "local_name_identifiers": [],
+              "phonetic_name_identifiers": []
+            },
+            "geographic_addresses": [
+              {
+                "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+                "department": "",
+                "sub_department": "",
+                "street_name": "Grimsby Road",
+                "building_number": "762",
+                "building_name": "",
+                "floor": "",
+                "post_box": "",
+                "room": "",
+                "post_code": "OX8 U89",
+                "town_name": "Oxford",
+                "town_location_name": "",
+                "district_name": "",
+                "country_sub_division": "",
+                "address_line": [],
+                "country": "GB"
+              }
+            ],
+            "customer_number": "",
+            "national_identification": {
+              "national_identifier": "213800AQUAUP6I215N33",
+              "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+              "country_of_issue": "GB",
+              "registration_authority": "RA000589"
+            },
+            "country_of_registration": "GB"
+          }
+        }
+      },
+      "transfer_path": {
+        "transfer_path": []
+      },
+      "payload_metadata": {
+        "transliteration_method": []
+      }
+    }
+  }

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -8,6 +8,38 @@ import (
 	"gorm.io/gorm"
 )
 
+type Payload struct {
+	IVMS101   string
+	AssetType VirtualAsset
+	Amount    float64
+	Callback  string
+}
+
+type VirtualAsset uint16
+
+const (
+	UnknownAsset VirtualAsset = iota
+	Bitcoin
+	Tether
+	Ethereum
+	Litecoin
+	XRP
+	BitcoinCash
+	Tezos
+	EOS
+)
+
+type TransferReply struct {
+	Approved string
+	Rejected string
+	Callback string
+}
+
+type TransferConfirmation struct {
+	TxId     string
+	Canceled string
+}
+
 type Transfer struct {
 	gorm.Model
 	TransferID     uuid.UUID      `gorm:"uniqueIndex;size:255;column:transfer_id;not null"`

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -29,20 +29,6 @@ const (
 	Rejected
 )
 
-type VirtualAsset uint16
-
-const (
-	UnknownAsset VirtualAsset = iota
-	Bitcoin
-	Tether
-	Ethereum
-	Litecoin
-	XRP
-	BitcoinCash
-	Tezos
-	EOS
-)
-
 type Customer struct {
 	gorm.Model
 	CustomerID    uuid.UUID    `gorm:"uniqueIndex;size:255;column:customer_id;not null"`

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -14,7 +14,7 @@ type Transfer struct {
 	Status         TransferStatus `gorm:"column:status;not null"`
 	OriginatorVasp string         `gorm:"column:originator_vasp;not null"`
 	Originator     string         `gorm:"column:originator;not null"`
-	Beneficiaary   string         `gorm:"column:beneficiary;not null"`
+	Beneficiary    string         `gorm:"column:beneficiary;not null"`
 	AssetType      VirtualAsset   `gorm:"column:asset_type;not null"`
 	Amount         float64        `gorm:"column:amount;not null"`
 	Created        time.Time      `gorm:"column:created;not null"`

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -1,0 +1,76 @@
+package openvasp
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type Transfer struct {
+	gorm.Model
+	TransferID     uuid.UUID      `gorm:"uniqueIndex;size:255;column:transfer_id;not null"`
+	Status         TransferStatus `gorm:"column:status;not null"`
+	OriginatorVasp string         `gorm:"column:originator_vasp;not null"`
+	Originator     string         `gorm:"column:originator;not null"`
+	Beneficiaary   string         `gorm:"column:beneficiary;not null"`
+	AssetType      VirtualAsset   `gorm:"column:asset_type;not null"`
+	Amount         float64        `gorm:"column:amount;not null"`
+	Created        time.Time      `gorm:"column:created;not null"`
+}
+
+type TransferStatus uint16
+
+const (
+	UnknownStatus TransferStatus = iota
+	Pending
+	Approved
+	Rejected
+)
+
+type VirtualAsset uint16
+
+const (
+	UnknownAsset VirtualAsset = iota
+	Bitcoin
+	Tether
+	Ethereum
+	Litecoin
+	XRP
+	BitcoinCash
+	Tezos
+	EOS
+)
+
+type Customer struct {
+	gorm.Model
+	CustomerID    uuid.UUID    `gorm:"uniqueIndex;size:255;column:customer_id;not null"`
+	Name          string       `gorm:"column:name;not null"`
+	AssetType     VirtualAsset `gorm:"column:asset_type;not null"`
+	WalletAddress string       `gorm:"column:wallet_address;not null"`
+	TravelAddress string       `gorm:"column:travel_address;not null"`
+}
+
+type server struct {
+	db *gorm.DB
+}
+
+func New(dsn string) (newServer *server, err error) {
+	newServer = &server{}
+	if newServer.db, err = openDB(dsn); err != nil {
+		return nil, err
+	}
+	return newServer, nil
+}
+
+func openDB(dsn string) (db *gorm.DB, err error) {
+	if db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{}); err != nil {
+		return nil, err
+	}
+
+	if err = db.AutoMigrate(&Customer{}); err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -24,6 +24,7 @@ type Payload struct {
 	AssetType VirtualAsset
 	Amount    float64
 	Callback  string
+	Reject    bool
 }
 
 type VirtualAsset uint16

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -8,7 +8,10 @@ import (
 	"gorm.io/gorm"
 )
 
-//
+// The Customer struct binds to JSON sent to
+// the Register endpoint when executing
+// registering a contact and is used to store
+// contacts in the database
 type Customer struct {
 	gorm.Model
 	CustomerID    uuid.UUID    `gorm:"uniqueIndex;size:255;column:customer_id;not null"`
@@ -18,7 +21,8 @@ type Customer struct {
 	TravelAddress string       `gorm:"column:travel_address;not null"`
 }
 
-//
+// The Payload struct binds to JSON sent to
+// the Transfer endpoint
 type Payload struct {
 	IVMS101   string
 	AssetType VirtualAsset
@@ -41,7 +45,9 @@ const (
 	EOS
 )
 
-//
+// The Transfer struct is constructed from
+// Payload data sent to the transfer endpoint
+// and is used to store transfers in the database
 type Transfer struct {
 	gorm.Model
 	TransferID     uuid.UUID      `gorm:"uniqueIndex;size:255;column:transfer_id;not null"`
@@ -63,7 +69,7 @@ const (
 	Rejected
 )
 
-// TransferApproval struct is to be sent to
+// TransferApproval struct binds to JSON sent to
 // the TransferInquiry endpoint when executing
 // the callback provided by a Transfer call
 type TransferReply struct {
@@ -76,7 +82,8 @@ type TransferApproval struct {
 	Callback string
 }
 
-//
+// TransferConfirmation struct binds to JSON sent to
+// the TransferConfirmation endpoint
 type TransferConfirmation struct {
 	TxId     string
 	Canceled string

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -55,7 +55,7 @@ func openDB(dsn string) (db *gorm.DB, err error) {
 		return nil, err
 	}
 
-	if err = db.AutoMigrate(&Customer{}); err != nil {
+	if err = db.AutoMigrate(&Customer{}, &Transfer{}); err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/pkg/openvasp/web-service-gin/db.go
+++ b/pkg/openvasp/web-service-gin/db.go
@@ -14,7 +14,7 @@ type Transfer struct {
 	Status         TransferStatus `gorm:"column:status;not null"`
 	OriginatorVasp string         `gorm:"column:originator_vasp;not null"`
 	Originator     string         `gorm:"column:originator;not null"`
-	Beneficiary    string         `gorm:"column:beneficiary;not null"`
+	Beneficiaary   string         `gorm:"column:beneficiary;not null"`
 	AssetType      VirtualAsset   `gorm:"column:asset_type;not null"`
 	Amount         float64        `gorm:"column:amount;not null"`
 	Created        time.Time      `gorm:"column:created;not null"`

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -44,7 +44,7 @@ type TransferApproval struct {
 }
 
 type TransferConfirmation struct {
-	TxId     uuid.UUID
+	TxId     string
 	Canceled string
 }
 
@@ -313,10 +313,10 @@ func (s *server) TransferConfirmation(c *gin.Context) {
 
 func validateConfirmation(confirmation *TransferConfirmation) error {
 	err := errors.New("confirmation must either have transfer ID or cancelation")
-	if confirmation.TxId == uuid.Nil && confirmation.Canceled == "" {
+	if confirmation.TxId == "" && confirmation.Canceled == "" {
 		return err
 	}
-	if confirmation.TxId != uuid.Nil && confirmation.Canceled != "" {
+	if confirmation.TxId != "" && confirmation.Canceled != "" {
 		return err
 	}
 	return nil

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -351,7 +351,7 @@ func (s *server) TransferConfirmation(c *gin.Context) {
 			c.IndentedJSON(http.StatusInternalServerError, gin.H{"Could not reject transfer": db.Error})
 		}
 	}
-	c.Status(http.StatusOK)
+	c.IndentedJSON(http.StatusOK, "transfer confirmation was successfull")
 }
 
 // Helper function to ensure that the JSON provided to the

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -198,7 +198,7 @@ func (s *server) Transfer(c *gin.Context) {
 				},
 			})
 	} else {
-		c.IndentedJSON(http.StatusAccepted, &TransferReply{Rejected: "The Transfer has been rejected"})
+		c.IndentedJSON(http.StatusAccepted, &TransferReply{Rejected: fmt.Sprintf(`transfer "%s" has been rejected`, newTransfer.TransferID)})
 	}
 }
 

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -170,8 +170,10 @@ func (s *server) Transfer(c *gin.Context) {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"Could not register customer": db.Error})
 		return
 	}
+	c.IndentedJSON(http.StatusCreated, &newTransfer)
 }
 
+//TODO: implement
 func validatePayload(payload *Payload) (err error) {
 	return nil
 }

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -13,16 +13,10 @@ import (
 )
 
 type Payload struct {
-	IVMS101  Identity
-	Asset    VirtualAsset
+	IVMS101  *trisa.IdentityPayload
+	Asset    string
 	Amount   float64
 	Callback string
-}
-
-type Identity struct {
-	Originator      *trisa.Originator      `json:"originator,omitempty"`
-	Beneficiary     *trisa.Beneficiary     `json:"beneficiary,omitempty"`
-	OriginatingVASP *trisa.OriginatingVasp `json:"originatingVASP,omitempty"`
 }
 
 type VirtualAsset uint16
@@ -85,7 +79,7 @@ Example command:
 			--request "POST" --data '{"name":"Tildred Milcot", "assettype": 3, "walletaddress": "926ca69a-6c22-42e6-9105-11ab5de1237b"}'
 */
 func (s *server) Register(c *gin.Context) {
-	fmt.Printf("Request: %d\n", c.Request)
+	fmt.Printf("Request: %+v\n", c.Request)
 
 	var err error
 	var newCustomer Customer
@@ -93,6 +87,7 @@ func (s *server) Register(c *gin.Context) {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"Could not bind request": err.Error()})
 		return
 	}
+	fmt.Printf("New Customer: %+v\n", &newCustomer)
 
 	if err = validateCustomer(&newCustomer); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"Invalid customer provided": err.Error()})
@@ -109,7 +104,7 @@ func (s *server) Register(c *gin.Context) {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"Could not register customer": db.Error})
 		return
 	}
-	c.IndentedJSON(http.StatusCreated, newCustomer)
+	c.IndentedJSON(http.StatusCreated, &newCustomer)
 }
 
 // Validate that the Registration JSON is valid
@@ -132,13 +127,11 @@ func validateCustomer(customer *Customer) (err error) {
 	return nil
 }
 
-func (s *server) listUsers(c *gin.Context) {
+//TODO: implement
+func (s *server) listUsers(c *gin.Context) {}
 
-}
-
-func (s *server) getLNURL(c *gin.Context) {
-
-}
+//TODO: implement
+func (s *server) getLNURL(c *gin.Context) {}
 
 func (s *server) Transfer(c *gin.Context) {
 	var err error
@@ -154,14 +147,14 @@ func (s *server) Transfer(c *gin.Context) {
 	}
 
 	newTransfer := &Transfer{
-		TransferID:     uuid.New(),
-		Status:         Pending,
-		OriginatorVasp: newPayload.IVMS101.OriginatingVASP.String(),
-		Originator:     newPayload.IVMS101.Originator.String(),
-		Beneficiary:    newPayload.IVMS101.Beneficiary.String(),
-		AssetType:      newPayload.Asset,
-		Amount:         newPayload.Amount,
-		Created:        time.Now(),
+		TransferID: uuid.New(),
+		Status:     Pending,
+		//OriginatorVasp: newPayload.IVMS101.OriginatingVASP.String(),
+		Originator: newPayload.IVMS101.Originator.String(),
+		//Beneficiary: newPayload.IVMS101.Beneficiary.String(),
+		//AssetType:      newPayload.Asset,
+		Amount:  newPayload.Amount,
+		Created: time.Now(),
 	}
 
 	if db := s.db.Create(&newTransfer); db.Error != nil {

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Payload struct {
-	IVMS101   trisa.IdentityPayload `binding:"required"`
-	AssetType VirtualAsset          `binding:"required"`
-	Amount    float64               `binding:"required"`
-	Callback  string                `binding:"required"`
+	IVMS101   *trisa.IdentityPayload `binding:"required"`
+	AssetType VirtualAsset           `binding:"required"`
+	Amount    float64                `binding:"required"`
+	Callback  string                 `binding:"required"`
 }
 
 type VirtualAsset uint16
@@ -210,8 +210,22 @@ func (s *server) Transfer(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, &newTransfer)
 }
 
-//TODO: implement
 func validatePayload(payload *Payload) (err error) {
+	if payload.IVMS101 == nil {
+		return errors.New("ivms101 payload must be set")
+	}
+
+	if payload.AssetType == UnknownAsset {
+		return errors.New("asset type must be set")
+	}
+
+	if payload.Amount == 0 {
+		return errors.New("transfer amount must be set")
+	}
+
+	if payload.Callback == "" {
+		return errors.New("callback must be set")
+	}
 	return nil
 }
 

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -8,57 +8,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	lnurl "github.com/xplorfin/lnurlauth"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-)
-
-type Customer struct {
-	gorm.Model
-	CustomerID    uuid.UUID    `gorm:"uniqueIndex;size:255;column:customer_id;not null"`
-	Name          string       `gorm:"column:name;null"`
-	AssetType     VirtualAsset `gorm:"column:asset_type;null"`
-	WalletAddress string       `gorm:"column:wallet_address;null"`
-	TravelAddress string       `gorm:"column:travel_address;null"`
-}
-
-type VirtualAsset uint16
-
-const (
-	UnknownAsset VirtualAsset = iota
-	Bitcoin
-	Tether
-	Ethereum
-	Litecoin
-	XRP
-	BitcoinCash
-	Tezos
-	EOS
 )
 
 const travelURLTemplate = "https://test.net/transfer/%s?tag=travelRuleInquiry"
-
-type server struct {
-	db *gorm.DB
-}
-
-func New(dsn string) (newServer *server, err error) {
-	newServer = &server{}
-	if newServer.db, err = openDB(dsn); err != nil {
-		return nil, err
-	}
-	return newServer, nil
-}
-
-func openDB(dsn string) (db *gorm.DB, err error) {
-	if db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{}); err != nil {
-		return nil, err
-	}
-
-	if err = db.AutoMigrate(&Customer{}); err != nil {
-		return nil, err
-	}
-	return db, nil
-}
 
 func Serve(address, dsn string) (err error) {
 	var s *server

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -62,8 +62,6 @@ func (p *Payload) BeneficiaryName() string {
 	return fmt.Sprintf("%s %s", nameIds.PrimaryIdentifier, nameIds.SecondaryIdentifier)
 }
 
-const travelURLTemplate = "https://test.net/transfer/%s?tag=travelRuleInquiry"
-
 func Serve(address, dsn string) (err error) {
 	var s *server
 	if s, err = New(dsn); err != nil {

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Payload struct {
-	IVMS101  *trisa.IdentityPayload
-	Asset    VirtualAsset
-	Amount   float64
-	Callback string
+	IVMS101   *trisa.IdentityPayload
+	AssetType VirtualAsset
+	Amount    float64
+	Callback  string
 }
 
 type VirtualAsset uint16
@@ -188,13 +188,15 @@ func (s *server) Transfer(c *gin.Context) {
 		return
 	}
 
+	fmt.Println(newPayload)
+
 	newTransfer := &Transfer{
 		TransferID:     uuid.New(),
 		Status:         Pending,
 		OriginatorVasp: newPayload.OriginatorName(),
 		Originator:     newPayload.OriginatorName(),
 		Beneficiary:    newPayload.BeneficiaryName(),
-		AssetType:      newPayload.Asset,
+		AssetType:      newPayload.AssetType,
 		Amount:         newPayload.Amount,
 		Created:        time.Now(),
 	}

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Payload struct {
-	IVMS101   *trisa.IdentityPayload
-	AssetType VirtualAsset
-	Amount    float64
-	Callback  string
+	IVMS101   trisa.IdentityPayload `binding:"required"`
+	AssetType VirtualAsset          `binding:"required"`
+	Amount    float64               `binding:"required"`
+	Callback  string                `binding:"required"`
 }
 
 type VirtualAsset uint16
@@ -91,6 +91,8 @@ Example command:
 			--request "POST" --data '{"name":"Tildred Milcot", "assettype": 3, "walletaddress": "926ca69a-6c22-42e6-9105-11ab5de1237b"}'
 */
 func (s *server) Register(c *gin.Context) {
+	fmt.Println(c.Request)
+
 	var err error
 	var newCustomer Customer
 	if err = c.BindJSON(&newCustomer); err != nil {
@@ -176,6 +178,8 @@ func (s *server) getLNURL(c *gin.Context) {
 }
 
 func (s *server) Transfer(c *gin.Context) {
+	fmt.Println(c.Request)
+
 	var err error
 	var newPayload Payload
 	if err = c.BindJSON(&newPayload); err != nil {
@@ -188,14 +192,12 @@ func (s *server) Transfer(c *gin.Context) {
 		return
 	}
 
-	fmt.Println(newPayload)
-
 	newTransfer := &Transfer{
 		TransferID:     uuid.New(),
 		Status:         Pending,
-		OriginatorVasp: newPayload.OriginatorName(),
 		Originator:     newPayload.OriginatorName(),
 		Beneficiary:    newPayload.BeneficiaryName(),
+		OriginatorVasp: newPayload.OriginatorName(),
 		AssetType:      newPayload.AssetType,
 		Amount:         newPayload.Amount,
 		Created:        time.Now(),

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -10,6 +10,43 @@ import (
 	lnurl "github.com/xplorfin/lnurlauth"
 )
 
+type Payload struct {
+	// TODO: import IVMS101
+	IVMS101  interface{}
+	Asset    VirtualAsset
+	Amount   float64
+	Callback string
+}
+
+type VirtualAsset uint16
+
+const (
+	UnknownAsset VirtualAsset = iota
+	Bitcoin
+	Tether
+	Ethereum
+	Litecoin
+	XRP
+	BitcoinCash
+	Tezos
+	EOS
+)
+
+type TransferReply struct {
+	Approved TransferApproval
+	Rejected string
+}
+
+type TransferApproval struct {
+	Approved string
+	Callback string
+}
+
+type TransferConfirmation struct {
+	TxId     uuid.UUID
+	Canceled string
+}
+
 const travelURLTemplate = "https://test.net/transfer/%s?tag=travelRuleInquiry"
 
 func Serve(address, dsn string) (err error) {
@@ -21,6 +58,8 @@ func Serve(address, dsn string) (err error) {
 	router := gin.Default()
 	router.POST("/register", s.Register)
 	router.POST("/transfer", s.Transfer)
+	router.POST("/inquiryResolution", s.InquiryResolution)
+	router.POST("/transferConfirmation", s.TransferConfirmation)
 	router.Run(address)
 	return nil
 }
@@ -84,3 +123,9 @@ func validateCustomer(customer *Customer) (err error) {
 
 //TODO: implement
 func (s *server) Transfer(c *gin.Context) {}
+
+//TODO: implement
+func (s *server) InquiryResolution(c *gin.Context) {}
+
+//TODO: implement
+func (s *server) TransferConfirmation(c *gin.Context) {}

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -138,7 +138,7 @@ func (s *server) ListUsers(c *gin.Context) {
 		}
 		users = append(users, newUser)
 	}
-	c.IndentedJSON(http.StatusFound, &users)
+	c.IndentedJSON(http.StatusOK, &users)
 }
 
 type user struct {
@@ -165,7 +165,7 @@ func (s *server) GetTravelAddress(c *gin.Context) {
 		Name:       customer.Name,
 		LNURL:      customer.TravelAddress,
 	}
-	c.IndentedJSON(http.StatusFound, &foundUser)
+	c.IndentedJSON(http.StatusOK, &foundUser)
 }
 
 //
@@ -271,7 +271,7 @@ func (s *server) GetTransfer(c *gin.Context) {
 	if db := s.db.Where("transfer_id = ?", TransferID).First(&TransferID); db.Error != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"Could not find transfer": db.Error})
 	}
-	c.IndentedJSON(http.StatusFound, &transfer)
+	c.IndentedJSON(http.StatusOK, &transfer)
 }
 
 //

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -148,7 +148,7 @@ func (s *server) Transfer(c *gin.Context) {
 		c.IndentedJSON(http.StatusBadRequest, gin.H{"Could not bind request": err.Error()})
 		return
 	}
-	//TODO:
+	//TODO: Find a better way to avoid binding issues with quotes
 	newPayload.IVMS101 = strings.ReplaceAll(newPayload.IVMS101, `*`, `"`)
 	newPayload.IVMS101 = strings.ReplaceAll(newPayload.IVMS101, "+", "\n")
 

--- a/pkg/openvasp/web-service-gin/openvasp.go
+++ b/pkg/openvasp/web-service-gin/openvasp.go
@@ -230,8 +230,20 @@ func validatePayload(payload *Payload) (err error) {
 	return nil
 }
 
-//TODO: implement
-func (s *server) GetTransfer(c *gin.Context) {}
+func (s *server) GetTransfer(c *gin.Context) {
+	var err error
+	var TransferID uuid.UUID
+	if TransferID, err = uuid.Parse(c.Param("id")); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"Could not parse id": err.Error()})
+		return
+	}
+
+	var transfer Transfer
+	if db := s.db.Where("transfer_id = ?", TransferID).First(&TransferID); db.Error != nil {
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"Could not find transfer": db.Error})
+	}
+	c.IndentedJSON(http.StatusFound, &transfer)
+}
 
 func (s *server) InquiryResolution(c *gin.Context) {
 	fmt.Println(c.Request)


### PR DESCRIPTION
Implements the three endpoints that make up the TRP protocol.

These are the four important endpoints to test in this TRP implementation and their associated helper endpoints:

- register (with the helper endpoints listusers and gettraveladdress)
- transfer (with the helper endpoint gettransfer)
- transferinquiry
- transferconfirmation

Each of these four parts of the PR can be reviewed separately

An overview diagram of the TRP protocol can be found here: https://gitlab.com/OpenVASP/travel-rule-protocol/-/blob/master/core/specification.md#overview

And the expected protocol flow can be found here: https://gitlab.com/OpenVASP/travel-rule-protocol/-/blob/master/core/specification.md#detailed-protocol-flow

To run the TRP server you should `go install ` the CLI tool found in `https://github.com/trisacrypto/testnet/cmd/openvasp/main.go` provides commands for interacting with each endpoint in the Gin server.

### For TRP server as Beneficiary 
The initial step for the TRP protocol (at least in this implementation) would be to register a new contact with the TRP server and generate an LNURL for that contact. You can use the CLI tool's `register` command to test this endpoint, the address of the gin server and the name, asset type and wallet address of the OpenVASP customer with the command's flags, but defaults are also currently provided for this as well as every other command.

You can see a list of the registered users by calling the `listusers` endpoint or using it's corresponding CLI command. You can also use the `gettraveladdress` to list a specific user's LNURL.

The next step is to initiate a TRP transfer using the LNURL generated by registering the new contact. The LNURL should be given to the transfer command through the CLI. After the transfer command has run successfully you get view the created pending transfer with the `gettransfer` endpoint or it's corresponding command, providing the transfer id of the transfer, returned by the `transfer endpoint`.

The last endpoint for beneficiary testing is the transferconfirmation endpoint. Sending either a confirmation (a txid) or a rejection to that endpoint is the last part of the TRP protocol. There is a CLI command called `confirm` for testing this endpoint.

### For TRP server as Originator
For the end-to-end demo we'll need to use 21 Analytics server, but as far as reviewing and testing this we just need to make sure that the transferinquiry endpoint works as expected based on the TRP spec and expected protocol flow. There is a CLI command called `resolve` for testing this endpoint.